### PR TITLE
camply 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ versioning.
 - Any bugs that surface will quickly have fixes quickly deployed before version
   `1.0.0` is released.
 
+## [0.1.2] - 2021-05-24
+
+### Fixed
+
+- Filter out `Checkout-Only` campsites by excluding `Open` availability status
+- No longer trapping all errors with `exit(0)`
+- Email notifications now attempt login at start, to throw errors early.
+
 ## [0.1.1] - 2021-05-18
 
 ### Added
@@ -34,6 +42,8 @@ versioning.
 - Integrations with https://recreation.gov and https://yellowstonenationalparklodges.com
 
 [unreleased]: https://github.com/juftin/camply/compare/main...integration
+
+[0.1.2]: https://github.com/juftin/camply/compare/v0.1.1...v0.1.2
 
 [0.1.1]: https://github.com/juftin/camply/compare/v0.1.0...v0.1.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim
 
 MAINTAINER Justin Flannery <juftin@juftin.com>
-LABEL version="0.1.1"
+LABEL version="0.1.2"
 LABEL description="camply, the campsite finder"
 
 COPY . /tmp/camply

--- a/camply/__init__.py
+++ b/camply/__init__.py
@@ -5,3 +5,5 @@
 """
 camply __init__ file
 """
+
+__version__ = "0.1.2"

--- a/camply/config/api_config.py
+++ b/camply/config/api_config.py
@@ -98,12 +98,13 @@ class RecreationBookingConfig:
     RATE_LIMITING: float = round(uniform(1.01, 1.51), 2)
 
     CAMPSITE_UNAVAILABLE_STRINGS: list = [
-        "Reserved",
-        "Not Available",
-        "Not Reservable",
-        "Not Reservable Management",
-        "Not Available Cutoff",
-        "Lottery"
+        "Reserved"
+        , "Not Available"
+        , "Not Reservable"
+        , "Not Reservable Management"
+        , "Not Available Cutoff"
+        , "Lottery"
+        , "Open"
     ]
 
     CAMPSITE_BASE: str = "campsites"

--- a/camply/config/cli_config.py
+++ b/camply/config/cli_config.py
@@ -11,6 +11,7 @@ from os import getenv
 
 from dotenv import load_dotenv
 
+from camply import __version__ as camply_version
 from camply.config.file_config import FileConfig
 from camply.config.search_config import SearchConfig
 
@@ -122,7 +123,7 @@ class CommandLineConfig(CommandLineActions, CommandLineArguments, CommandLineVal
     """
 
     CAMPLY_APP_NAME: str = "camply"
-    CAMPLY_APP_VERSION: str = "0.1.2"
+    CAMPLY_APP_VERSION: str = camply_version
     CAMPLY_DESCRIPTION: str = "camply, the campsite finder"
     CAMPLY_EXIT_MESSAGE: str = "Exiting camply 👋"
 

--- a/camply/config/cli_config.py
+++ b/camply/config/cli_config.py
@@ -122,7 +122,7 @@ class CommandLineConfig(CommandLineActions, CommandLineArguments, CommandLineVal
     """
 
     CAMPLY_APP_NAME: str = "camply"
-    CAMPLY_APP_VERSION: str = "0.1.1"
+    CAMPLY_APP_VERSION: str = "0.1.2"
     CAMPLY_DESCRIPTION: str = "camply, the campsite finder"
     CAMPLY_EXIT_MESSAGE: str = "Exiting camply 👋"
 

--- a/camply/notifications/email_notifications.py
+++ b/camply/notifications/email_notifications.py
@@ -24,9 +24,20 @@ class EmailNotifications(BaseNotifications, ABC):
     Notifications via Email
     """
 
+    email_subject = EmailConfig.EMAIL_SUBJECT_LINE
+    email_from = EmailConfig.EMAIL_FROM_ADDRESS
+    email_to = EmailConfig.EMAIL_TO_ADDRESS
+    email_username = EmailConfig.EMAIL_USERNAME
+    _email_password = EmailConfig.EMAIL_PASSWORD
+    email_smtp_server = EmailConfig.EMAIL_SMTP_SERVER
+    email_smtp_server_port = EmailConfig.EMAIL_SMTP_PORT
+
     def __init__(self):
         """
         Data Validation
+
+        **kwargs
+            Accepts: from, to, subject, username, password, server, port
         """
         # PERFORM SOME VALIDATION
         if any([EmailConfig.EMAIL_TO_ADDRESS in [None, ""],
@@ -41,6 +52,13 @@ class EmailNotifications(BaseNotifications, ABC):
                              f"{optional_variable_names}")
             logger.error(error_message)
             raise EnvironmentError(error_message)
+        # ATTEMPT AN EMAIL LOGIN AT INIT TO THROW ERRORS EARLY
+        _email_server = SMTP_SSL(EmailNotifications.email_smtp_server,
+                                 EmailNotifications.email_smtp_server_port)
+        _email_server.ehlo()
+        _email_server.login(user=EmailNotifications.email_username,
+                            password=EmailNotifications._email_password)
+        _email_server.quit()
 
     def __repr__(self):
         return "<EmailNotifications>"
@@ -63,16 +81,16 @@ class EmailNotifications(BaseNotifications, ABC):
         """
         email = EmailMessage()
         email.set_content(message)
-        email["Subject"] = kwargs.get("subject", EmailConfig.EMAIL_SUBJECT_LINE)
-        email["From"] = kwargs.get("from", EmailConfig.EMAIL_FROM_ADDRESS)
-        email["To"] = kwargs.get("to", EmailConfig.EMAIL_TO_ADDRESS)
-        email_server_user = kwargs.get("username", EmailConfig.EMAIL_USERNAME)
+        email["Subject"] = kwargs.get("subject", EmailNotifications.email_subject)
+        email["From"] = kwargs.get("from", EmailNotifications.email_from)
+        email["To"] = kwargs.get("to", EmailNotifications.email_to)
+        email_server_user = kwargs.get("username", EmailNotifications.email_username)
         email_server_password = kwargs.get("password",
-                                           EmailConfig.EMAIL_PASSWORD)
+                                           EmailNotifications._email_password)
         email_server_smtp_server = kwargs.get("server",
-                                              EmailConfig.EMAIL_SMTP_SERVER)
+                                              EmailNotifications.email_smtp_server)
         email_server_smtp_server_port = kwargs.get("port",
-                                                   EmailConfig.EMAIL_SMTP_PORT)
+                                                   EmailNotifications.email_smtp_server_port)
         email_server = SMTP_SSL(email_server_smtp_server,
                                 email_server_smtp_server_port)
         email_server.ehlo()

--- a/camply/utils/camply_cli.py
+++ b/camply/utils/camply_cli.py
@@ -42,7 +42,6 @@ def main():
         logger.debug("Handling Exit Request")
     finally:
         logger.camply(CommandLineConfig.CAMPLY_EXIT_MESSAGE)
-        exit(0)
 
 
 class CommandLineError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "camply"
-version = "0.1.1"
+version = "0.1.2"
 description = "camply, the campsite finder ⛺️"
 authors = ["Justin Flannery <juftin@juftin.com>"]
 maintainers = ["Justin Flannery <juftin@juftin.com>"]

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ from os import path
 
 from setuptools import setup
 
+from camply import __version__ as camply_version
+
 packages = ["camply",
             "camply.config",
             "camply.notifications",
@@ -36,7 +38,7 @@ with open(path.join(root_directory, "README.md"), encoding="utf-8") as f:
 
 setup_kwargs = {
     "name": "camply",
-    "version": "0.1.2",
+    "version": camply_version,
     "description": "camply, the campsite finder",
     "long_description": long_description,
     "long_description_content_type": "text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open(path.join(root_directory, "README.md"), encoding="utf-8") as f:
 
 setup_kwargs = {
     "name": "camply",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "camply, the campsite finder",
     "long_description": long_description,
     "long_description_content_type": "text/markdown",


### PR DESCRIPTION
# camply 0.1.2

## [0.1.2] - 2021-05-24

### Fixed

- Filter out `Checkout-Only` campsites by excluding `Open` availability status
- No longer trapping all errors with `exit(0)`
- Email notifications now attempt login at start, to throw errors early.

[0.1.2]: https://github.com/juftin/camply/compare/v0.1.1...v0.1.2
