### PR TITLE
Fix parsing facilities responses

### DIFF
--- a/camply/providers/recreation_dot_gov/campsite_search.py
+++ b/camply/providers/recreation_dot_gov/campsite_search.py
@@ -310,7 +310,7 @@ class RecreationDotGov(BaseProvider):
         try:
             facility_state = facility[RIDBConfig.FACILITY_ADDRESS][0][
                 RIDBConfig.FACILITY_LOCATION_STATE].upper()
-        except IndexError:
+        except (KeyError, IndexError):
             facility_state = "USA"
         try:
             recreation_area = facility[RIDBConfig.CAMPGROUND_RECREATION_AREA][0][
@@ -323,7 +323,7 @@ class RecreationDotGov(BaseProvider):
                                                      facility_id=facility_id,
                                                      recreation_area_id=recreation_area_id)
             return facility, campground_facility
-        except IndexError:
+        except (KeyError, IndexError):
             return facility, None
 
     @classmethod


### PR DESCRIPTION
Fix parsing facilities responses without `FACILITY_ADDRESS` or `CAMPGROUND_RECREATION_AREA` by adding `except KeyError`

Sample facility response from 89898:
```
{'FacilityID': '', 'LegacyFacilityID': '', 'OrgFacilityID': '', 'ParentOrgID': '', 'ParentRecAreaID': '', 'FacilityName': '', 'FacilityDescription': '', 'FacilityTypeDescription': '', 'FacilityUseFeeDescription': '', 'FacilityDirections': '', 'FacilityPhone': '', 'FacilityEmail': '', 'FacilityReservationURL': '', 'FacilityMapURL': '', 'FacilityAdaAccess': '', 'GEOJSON': {'TYPE': '', 'COORDINATES': None}, 'FacilityLongitude': 0, 'FacilityLatitude': 0, 'Keywords': '', 'StayLimit': '', 'Reservable': False, 'Enabled': False, 'LastUpdatedDate': ''}
```