### PR TITLE
Multiple Campsites Bugfix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,22 +11,24 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+Steps to reproduce the behavior - all of these are helpful:
+
+1. Your original camply command
+    - Even better, supply your camply command and output with the debug
+      command `camply --debug campsites ...`
+2. Your .camply file (minus any sensitive information)
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+If applicable, add screenshots or copy and paste your 
+terminal output to help explain your problem.
 
 **Environment (please complete the following information):**
 - OS: [e.g. Windows, Mac, Linux, Docker]
 - Python Version [e.g. 3.6, 3.9]
-- Camply Version [e.g. 0.1.1]
+- Camply Version [e.g. 0.4.7]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-    -   name:  Have a question about how to use camply?
+    -   name:  Have a question about how to use camply and not a bug report?
         url:   https://github.com/juftin/camply/discussions
         about: Check out camply discussions. There's lots of useful stuff there.

--- a/README.md
+++ b/README.md
@@ -96,33 +96,29 @@ and `configure`.
 ```text
 ❯ camply --help
 
-2021-05-17 19:11:59,858 [  CAMPLY]: camply, the campsite finder ⛺️
-usage: camply [-h] [--version]
-              {campsites,recreation-areas,campgrounds,configure} ...
+Usage: camply [OPTIONS] COMMAND [ARGS]...
 
-Welcome to camply, the campsite finder. Finding reservations at sold out
-campgrounds can be tough. That's where camply comes in. It searches the APIs
-of booking services like https://recreation.gov (which indexes thousands of
-campgrounds across the USA) to continuously check for cancellations and
-availabilities to pop up. Once a campsite becomes available, camply sends you
-a notification to book your spot!
+  Welcome to camply, the campsite finder.
 
-positional arguments:
-  {campsites,recreation-areas,campgrounds,configure}
-    campsites           Find available Campsites using search criteria
-    recreation-areas    Search for Recreation Areas and list them
-    campgrounds         Search for Campgrounds (inside of Recreation Areas)
-                        and list them
-    configure           Set up camply configuration file with an interactive
-                        console
+  Finding reservations at sold out campgrounds can be tough. That's where
+  camply comes in. It searches the APIs of booking services like
+  https://recreation.gov (which indexes thousands of campgrounds across the
+  USA) to continuously check for cancellations and availabilities to pop up.
+  Once a campsite becomes available, camply sends you a notification to book
+  your spot!
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --version             show program's version number and exit
+  visit the camply documentation at https://github.com/juftin/camply
 
-visit the camply documentation at https://github.com/juftin/camply
+Options:
+  --version             Show the version and exit.
+  --debug / --no-debug  Enable extra debugging output.
+  --help                Show this message and exit.
 
-2021-05-17 19:11:59,863 [  CAMPLY]: Exiting camply 👋
+Commands:
+  campgrounds       Search for Campgrounds (inside of Recreation Areas)...
+  campsites         Find available Campsites using search criteria
+  configure         Set up camply configuration file with an interactive...
+  recreation-areas  Search for Recreation Areas and list them
 ```
 
 ### `campsites`

--- a/camply/_version.py
+++ b/camply/_version.py
@@ -2,5 +2,5 @@
 camply __version__ file
 """
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 __camply__ = "camply"

--- a/camply/cli.py
+++ b/camply/cli.py
@@ -23,8 +23,11 @@ logger = logging.getLogger(__name__)
 
 @click.group()
 @click.version_option(version=__version__, prog_name=__camply__)
+@click.option(
+    "--debug/--no-debug", default=False, help="Enable extra debugging output."
+)
 @click.pass_context
-def camply_command_line(ctx: click.core.Context) -> None:
+def camply_command_line(ctx: click.core.Context, debug: bool) -> None:
     """
     Welcome to camply, the campsite finder.
 
@@ -37,6 +40,11 @@ def camply_command_line(ctx: click.core.Context) -> None:
     visit the camply documentation at https://github.com/juftin/camply
     """
     ctx.ensure_object(dict)
+    ctx.obj["DEBUG"] = debug
+    set_up_logging(log_level=None if debug is False else logging.DEBUG)
+    if debug is True:
+        logger.debug("Setting up camply debugging")
+    traceback.install(show_locals=debug)
 
 
 @camply_command_line.command()
@@ -411,8 +419,6 @@ def cli():
     """
     Camply Command Line Utility Wrapper
     """
-    set_up_logging()
-    traceback.install(show_locals=False)
     try:
         logger.camply("camply, the campsite finder ⛺️")  # noqa
         camply_command_line()

--- a/camply/config/logging_config.py
+++ b/camply/config/logging_config.py
@@ -5,42 +5,67 @@ Dynamic Logging Configuration
 import logging
 import os
 from os import getenv
+from typing import Optional
 
 from rich.logging import RichHandler
 
-log_level = logging.getLevelName(getenv("LOG_LEVEL", "INFO").upper())
 
-rich_handler = RichHandler(
-    level=log_level,
-    rich_tracebacks=True,
-    omit_repeated_times=False,
-    show_path=False,
-)
+def get_log_handler(log_level: Optional[int] = None) -> logging.Handler:
+    """
+    Determine which logging handler should be used
 
-standard_handler = logging.StreamHandler()
-formatter = logging.Formatter("%(asctime)s [%(levelname)8s]: %(message)s")
-standard_handler.setFormatter(formatter)
-standard_handler.setLevel(log_level)
+    Parameters
+    ----------
+    log_level: Optional[int]
+        Which logging level should be used. If none is provided the LOG_LEVEL environment
+        variable will be used, defaulting to "INFO".
 
-_log_dict = {
-    "rich": rich_handler,
-    "python": standard_handler,
-}
-log_handler_name = os.getenv("CAMPLY_LOG_HANDLER", "rich")
-log_handler = _log_dict.get(log_handler_name.lower(), rich_handler)
+    Returns
+    -------
+    logging.Handler
+    """
+    if log_level is None:
+        log_level = logging.getLevelName(getenv("LOG_LEVEL", "INFO").upper())
+
+    rich_handler = RichHandler(
+        level=log_level,
+        rich_tracebacks=True,
+        omit_repeated_times=False,
+        show_path=False,
+    )
+
+    standard_handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(asctime)s [%(levelname)8s]: %(message)s")
+    standard_handler.setFormatter(formatter)
+    standard_handler.setLevel(log_level)
+
+    _log_dict = {
+        "rich": rich_handler,
+        "python": standard_handler,
+    }
+    log_handler_name = os.getenv("CAMPLY_LOG_HANDLER", "rich")
+    log_handler = _log_dict.get(log_handler_name.lower(), rich_handler)
+    return log_handler, log_level
 
 
-def set_up_logging() -> None:
+def set_up_logging(log_level: Optional[int] = None) -> None:
     """
     Set Up a Root Logger
+
+    Parameters
+    ----------
+    log_level: Optional[int]
+        Which logging level should be used. If none is provided the LOG_LEVEL environment
+        variable will be used, defaulting to "INFO".
     """
     kwargs = {}
+    log_handler, handler_level = get_log_handler(log_level=log_level)
     if isinstance(log_handler, RichHandler):
         kwargs["datefmt"] = "[%Y-%m-%d %H:%M:%S]"
         kwargs["format"] = "%(message)s"
         level = logging.NOTSET
     else:
-        level = log_level
+        level = handler_level
     logging.basicConfig(
         level=level,
         handlers=[

--- a/camply/providers/recreation_dot_gov/recdotgov_provider.py
+++ b/camply/providers/recreation_dot_gov/recdotgov_provider.py
@@ -6,6 +6,7 @@ import json
 import logging
 from base64 import b64decode
 from datetime import datetime, timedelta
+from itertools import chain
 from json import loads
 from random import choice
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -669,9 +670,9 @@ class RecreationDotGov(BaseProvider):
         cls,
         campsite_id: int,
         campsite_metadata: pd.DataFrame,
-    ):
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
         """
-        Index a DataFrame in a Complicated Way\
+        Index a DataFrame in a Complicated Way
         """
         try:
             equipment = campsite_metadata.at[campsite_id, "permitted_equipment"]
@@ -681,6 +682,12 @@ class RecreationDotGov(BaseProvider):
             attributes = campsite_metadata.at[campsite_id, "attributes"]
         except LookupError:
             attributes = None
+        if isinstance(equipment, pd.Series):
+            equipment = list(chain.from_iterable(equipment.drop_duplicates().tolist()))
+        if isinstance(attributes, pd.Series):
+            attributes = list(
+                chain.from_iterable(attributes.drop_duplicates().tolist())
+            )
         return equipment, attributes
 
     @classmethod

--- a/camply/search/search_recreationdotgov.py
+++ b/camply/search/search_recreationdotgov.py
@@ -108,7 +108,7 @@ class SearchRecreationDotGov(BaseCampingSearch):
             searchable_campgrounds = self._get_campgrounds_by_recreation_area_id()
         else:
             raise RuntimeError("You must provide a Campground or Recreation Area ID")
-        return searchable_campgrounds
+        return list(set(searchable_campgrounds))
 
     @classmethod
     def _get_searchable_equipment(

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -5,7 +5,7 @@ camply CLI
 .. code-block:: console
 
     ❯ camply --help
-    [2022-06-22 11:01:43] CAMPLY   camply, the campsite finder ⛺️
+
     Usage: camply [OPTIONS] COMMAND [ARGS]...
 
       Welcome to camply, the campsite finder.
@@ -20,15 +20,15 @@ camply CLI
       visit the camply documentation at https://github.com/juftin/camply
 
     Options:
-      --version  Show the version and exit.
-      --help     Show this message and exit.
+      --version             Show the version and exit.
+      --debug / --no-debug  Enable extra debugging output.
+      --help                Show this message and exit.
 
     Commands:
       campgrounds       Search for Campgrounds (inside of Recreation Areas)...
       campsites         Find available Campsites using search criteria
       configure         Set up camply configuration file with an interactive...
-      recreation-areas  Search for Recreation Areas and list them'
-    [2022-06-22 11:01:43] CAMPLY   Exiting camply 👋
+      recreation-areas  Search for Recreation Areas and list them
 
 
 ******************

--- a/tests/command_line_test.sh
+++ b/tests/command_line_test.sh
@@ -2,27 +2,39 @@
 
 set -ex
 
-camply recreation-areas --search "Yosemite National Park"
-camply campgrounds --rec-area 2991
-camply campgrounds --search "Fire Tower Lookout" --state CA
-camply campsites --rec-area 2991 --start-date 2022-09-15 --end-date 2022-09-17
-camply campsites --campground 252037 --start-date 2022-09-15 --end-date 2022-09-17
-camply campsites --yml-config tests/yml/example_search.yml
-camply campsites --campground 232045 --start-date 2022-07-15 --end-date 2022-10-01 --nights 5
-camply campsites --provider yellowstone --start-date 2022-10-10 --end-date 2022-10-16
-camply campsites --campsite 40107 --start-date 2022-09-15 --end-date 2022-09-17
-camply campgrounds --campsite 40107
-camply campsites --yml-config tests/yml/example_campsite_search.yml
+camply --debug recreation-areas --search "Yosemite National Park"
+camply --debug campgrounds --rec-area 2991
+camply --debug campgrounds --search "Fire Tower Lookout" --state CA
+camply --debug campsites --rec-area 2991 --start-date 2022-09-15 --end-date 2022-09-17
+camply --debug campsites --campground 252037 --start-date 2022-09-15 --end-date 2022-09-17
+camply --debug campsites --yml-config tests/yml/example_search.yml
+camply --debug campsites --campground 232045 --start-date 2022-07-15 --end-date 2022-10-01 --nights 5
+camply --debug campsites --provider yellowstone --start-date 2022-10-10 --end-date 2022-10-16
+camply --debug campsites --campsite 40107 --start-date 2022-09-15 --end-date 2022-09-17
+camply --debug campgrounds --campsite 40107
+camply --debug campsites --yml-config tests/yml/example_campsite_search.yml
 
-camply campsites \
+camply \
+  --debug \
+  campsites \
   --provider yellowstone \
   --start-date 2022-09-01 \
   --end-date 2022-09-14 \
   --campground YLYF:RV
 
-camply campsites \
+camply \
+    --debug \
+    campsites \
     --rec-area 2018 \
     --start-date 2022-09-09 \
     --end-date 2022-09-17 \
     --nights 3 \
     --equipment RV 25
+
+camply \
+  --debug \
+  campsites \
+  --campsite 84865 \
+  --campsite 84001 \
+  --start-date 2022-09-27 \
+  --end-date 2022-09-28


### PR DESCRIPTION
This pull request resolves https://github.com/juftin/camply/issues/100

When multiple campsites are searched the `_get_equipment_and_attributes` function was returning a pandas Series instead of a list of dictionaries. 

This PR also adds the ability to pass `--debug` to camply to see the local variables returned in traceback as well as to force DEBUG logging.