### PR TITLE
Bugfix: Release Token

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,7 +43,7 @@ jobs:
             run: |
                 poetry build --ansi
         -   name: Publish package on PyPI
-            uses: pypa/gh-action-pypi-publish@v1.5.0
+            uses: pypa/gh-action-pypi-publish@v1.5.1
             with:
                 user: __token__
                 password: ${{ secrets.PYPI_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
         -   name: Set up Docker Buildx
             uses: docker/setup-buildx-action@v1
         -   name: Login to DockerHub
-            uses: docker/login-action@v1
+            uses: docker/login-action@v2
             with:
                 username: ${{ secrets.DOCKER_USERNAME }}
                 password: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
             with:
                 fetch-depth: 2
                 ref: main
+                token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         -   name: Set up Python
             uses: actions/setup-python@v4
             with:
@@ -47,20 +48,16 @@ jobs:
             if: contains( github.event.pull_request.labels.*.name, 'BUMP_PATCH')
             run: |
                 poetry version patch
-        -   name: Setup Git Config
-            run: |
-                git config --global user.name "github-actions[bot]"
-                git config --global user.email "github-actions[bot]@users.noreply.github.com"
         -   name: Update Version Variable
             run: |
                 PROJECT_VERSION=$(poetry version --short)
                 REPLACED_VERSION_FILE_TEXT=$(grep -F -v "__version__" camply/_version.py)
                 echo "${REPLACED_VERSION_FILE_TEXT}" > camply/_version.py
                 echo "__version__ = \""${PROJECT_VERSION}\""" >> camply/_version.py
-                git add camply/_version.py
-                git add pyproject.toml
-                git commit -m "Version Bump - ${PROJECT_VERSION}" || true
-                git push
+        -   uses: EndBug/add-and-commit@v9
+            with:
+                default_author: github_actions
+                message: Version Bump - ${{ env.PROJECT_VERSION }}
 
     github-release:
         name: github-release


### PR DESCRIPTION
# Description

This PR fixes an issue where Releases can't be created due to branch protections

This PR will publish the release that https://github.com/juftin/camply/pull/110 was supposed to.

# Has This Been Tested?

Nope 🙈 

# Checklist:

- [x] I've read the contributing guidelines of this project
- [x] I've added a `BUMP_MAJOR`, `BUMP_MINOR`, or `BUMP_PATCH` label to this PR to increment the version
- [x] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation
