### PR TITLE
BugFix: Missing Release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ jobs:
     version-bump:
         name: version-bump
         runs-on: ubuntu-latest
+        if: ${{ !startsWith( github.event.head_commit.message, "Version Bump 🤖" ) }}
         steps:
         -   name: Check out the repository
             uses: actions/checkout@v3
@@ -17,15 +18,15 @@ jobs:
                 fetch-depth: 2
                 ref: main
                 token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        - name: Fetch Related Pull Request Information
-          uses: 8BitJonny/gh-get-current-pr@2.1.1
-          id: PR
-        - name: Fetch Related Pull Request Labels
-          run: |
-            echo PR_LABELS='${{ steps.PR.outputs.pr_labels }}' >> ${GITHUB_ENV}            
-            echo "LABELS: ${{ steps.PR.outputs.pr_labels }}"
-            echo "NUMBER: ${{ steps.PR.outputs.number }}"
-            echo "URL: ${{ steps.PR.outputs.pr_url }}"
+        -   name: Fetch Related Pull Request Information
+            uses: 8BitJonny/gh-get-current-pr@2.1.1
+            id: PR
+        -   name: Fetch Related Pull Request Labels
+            run: |
+                echo PR_LABELS='${{ steps.PR.outputs.pr_labels }}' >> ${GITHUB_ENV}
+                echo "LABELS: ${{ steps.PR.outputs.pr_labels }}"
+                echo "NUMBER: ${{ steps.PR.outputs.number }}"
+                echo "URL: ${{ steps.PR.outputs.pr_url }}"
         -   name: Set up Python
             uses: actions/setup-python@v4
             with:
@@ -69,12 +70,13 @@ jobs:
         -   uses: EndBug/add-and-commit@v9
             with:
                 default_author: github_actions
-                message: Version Bump - ${{ env.PROJECT_VERSION }}
+                message: Version Bump 🤖 ${{ env.PROJECT_VERSION }}
 
     github-release:
         name: github-release
         runs-on: ubuntu-latest
         needs: version-bump
+        if: ${{ startsWith( github.event.head_commit.message, "Version Bump 🤖" ) }}
         steps:
         -   name: Check out the repository
             uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,6 @@ jobs:
     github-release:
         name: github-release
         runs-on: ubuntu-latest
-        if: github.event.pull_request.merged == true
         needs: version-bump
         steps:
         -   name: Check out the repository

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,10 @@ on:
     push:
         branches:
         -   main
+        paths:
+        -   camply/**
+        -   pyproject.toml
+        -   .github/workflows/tests.yaml
     pull_request:
         branches: ['**']
     schedule:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,12 +4,12 @@ on:
     push:
         branches:
         -   main
+    pull_request:
+        branches: ['**']
         paths:
         -   camply/**
         -   pyproject.toml
         -   .github/workflows/tests.yaml
-    pull_request:
-        branches: ['**']
     schedule:
     -   cron: 0 12 1 * *
 jobs:

--- a/camply/notifications/slack.py
+++ b/camply/notifications/slack.py
@@ -122,7 +122,7 @@ class SlackNotifications(BaseNotifications):
                 blocks.append(
                     {
                         "type": "section",
-                        "fields": fields[chunk: chunk + 10],
+                        "fields": fields[chunk : chunk + 10],
                     }
                 )
             SlackNotifications.send_message(

--- a/camply/notifications/slack.py
+++ b/camply/notifications/slack.py
@@ -119,10 +119,11 @@ class SlackNotifications(BaseNotifications):
             )
             # Slack only allows 10 fields (k+v) per section
             for chunk in range(0, len(fields) + 1, 10):
+                chunk_max = chunk + 10
                 blocks.append(
                     {
                         "type": "section",
-                        "fields": fields[chunk : chunk + 10],
+                        "fields": fields[chunk:chunk_max],
                     }
                 )
             SlackNotifications.send_message(


### PR DESCRIPTION
# Description

This updates the current release process to run on merges to main, instead of on PR close. This allows Github Actions to use my personal secrets instead of the forked secrets of another user's repo.

This Also fixes the missing releases. 

# Has This Been Tested?

Kinda

# Checklist:

- [x] I've read the contributing guidelines of this project
- [x] I've added a `BUMP_MAJOR`, `BUMP_MINOR`, or `BUMP_PATCH` label to this PR to increment the version
- [x] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation
