### PR TITLE
Update documentation on how to specify multiple notification providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,18 +376,8 @@ camply campsites \
 #### Send a Notification to Different Services
 
 camply supports notifications from different providers. To send notifications to multiple providers
-just separate them with a comma. If you're adding spaces between the commas make sure to quote
-everything. You can also pass the --notifications parameter multiple times. YAML config entries also
+you can pass the --notifications parameter multiple times. YAML config entries also
 accept an array as well.
-
-```shell
-camply campsites \
-    --rec-area 2991 \
-    --start-date 2022-09-10 \
-    --end-date 2022-09-21 \
-    --continuous \
-    --notifications pushover,email
-```
 
 ```shell
 camply campsites \


### PR DESCRIPTION
Click doesn't support comma-separated value for multiple options:
 https://click.palletsprojects.com/en/8.1.x/options/#multiple-options

When trying to use a comma-separated list of values for `--notifications`, camply crashes.

Also note that I haven't made many/any contributions via Github before, so if I'm not following best practices please educate me! 