### PR TITLE
Notification Cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL description="camply, the campsite finder"
 COPY pyproject.toml /tmp/camply/pyproject.toml
 COPY camply/ /tmp/camply/camply/
 COPY README.md /tmp/camply/README.md
-RUN cd /tmp/camply/ && python -m pip install /tmp/camply/ && rm -rf /tmp/camply/
+RUN cd /tmp/camply/ && python -m pip install "/tmp/camply/[all]" && rm -rf /tmp/camply/
 
 ENV HOME=/home/camply
 RUN mkdir ${HOME}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ ___________
         + [Continuously Searching for A Campsite](#continuously-searching-for-a-campsite)
         + [Continue Looking After The First Match Is Found](#continue-looking-after-the-first-match-is-found)
         + [Send a Push Notification](#send-a-push-notification)
+        + [Send a Text Message](#send-a-text-message)
         + [Send a Notification to Different Services](#send-a-notification-to-different-services)
         + [Look for Weekend Campsite Availabilities](#look-for-weekend-campsite-availabilities)
         + [Look for Consecutive Nights at the Same Campsite](#look-for-consecutive-nights-at-the-same-campsite)
@@ -124,7 +125,7 @@ Commands:
   recreation-areas  Search for Recreation Areas and list them
 ```
 
-### `campsites`
+### campsites
 
 Search for a campsite within camply. Campsites are returned based on the search criteria provided.
 Campsites contain properties like booking date, site type (tent, RV, cabin, etc), capacity, price,
@@ -202,7 +203,7 @@ camply campsites \
     --end-date 2023-07-18
 ```
 
-### `recreation-areas`
+### recreation-areas
 
 Search for Recreation Areas and their IDs. Recreation Areas are places like National Parks and
 National Forests that can contain one or many campgrounds.
@@ -220,7 +221,7 @@ camply recreation-areas --search "Yosemite National Park"
 
 **_see the [examples](#search-for-recreation-areas-by-query-string) for more information_
 
-### `campgrounds`
+### campgrounds
 
 Search for Campgrounds and their IDs. Campgrounds are facilities inside of Recreation Areas that
 contain campsites. Most 'campgrounds' are areas made up of multiple campsites, others are facilities
@@ -243,7 +244,7 @@ camply campgrounds --search "Fire Tower Lookout" --state CA
 
 **_see the [examples](#look-for-specific-campgrounds-by-query-string) for more information_
 
-### `configure`
+### configure
 
 Set up `camply` configuration file with an interactive console
 
@@ -371,6 +372,28 @@ camply campsites \
     --end-date 2023-09-21 \
     --continuous \
     --notifications pushbullet
+```
+
+#### Send a Text Message
+
+If you want to sign up for a [Twilio](https://www.twilio.com/try-twilio) account, camply also supports
+sending text messages via SMS. You can set up your Twilio configuration via `camply configure`. You will need
+to set the following config values for Twilio: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`,
+`TWILIO_SOURCE_NUMBER`, `TWILIO_DEST_NUMBERS`.
+
+Sending text messages via Twilio also requires the `twilio` extras:
+
+```
+pip install camply[twilio]
+```
+
+```shell
+camply campsites \
+    --rec-area 2991 \
+    --start-date 2023-09-10 \
+    --end-date 2023-09-21 \
+    --continuous \
+    --notifications twilio
 ```
 
 #### Send a Notification to Different Services

--- a/camply/notifications/base_notifications.py
+++ b/camply/notifications/base_notifications.py
@@ -29,7 +29,6 @@ class BaseNotifications(ABC):
         """
         Instantiate with a Requests Session
         """
-
         self.session = requests.Session()
 
     def __repr__(self) -> str:

--- a/camply/notifications/base_notifications.py
+++ b/camply/notifications/base_notifications.py
@@ -6,6 +6,8 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Dict, List, Tuple
 
+import requests
+
 from camply.config import CampsiteContainerFields
 from camply.containers import AvailableCampsite
 
@@ -23,9 +25,21 @@ class BaseNotifications(ABC):
     Base Notifications
     """
 
-    @staticmethod
+    def __init__(self) -> None:
+        """
+        Instantiate with a Requests Session
+        """
+
+        self.session = requests.Session()
+
+    def __repr__(self) -> str:
+        """
+        String Representation
+        """
+        return f"<{self.__class__.__name__}>"
+
     @abstractmethod
-    def send_message(message: str, **kwargs):
+    def send_message(self, message: str, **kwargs):
         """
         Send a message
 
@@ -38,9 +52,8 @@ class BaseNotifications(ABC):
         """
         pass
 
-    @staticmethod
     @abstractmethod
-    def send_campsites(campsites: List[AvailableCampsite], **kwargs):
+    def send_campsites(self, campsites: List[AvailableCampsite], **kwargs):
         """
         Send a message with a campsite object
 

--- a/camply/notifications/email_notifications.py
+++ b/camply/notifications/email_notifications.py
@@ -33,6 +33,7 @@ class EmailNotifications(BaseNotifications):
         **kwargs
             Accepts: from, to, subject, username, password, server, port
         """
+        super().__init__()
         # PERFORM SOME VALIDATION
         if any(
             [
@@ -55,24 +56,17 @@ class EmailNotifications(BaseNotifications):
             raise EnvironmentError(error_message)
         # ATTEMPT AN EMAIL LOGIN AT INIT TO THROW ERRORS EARLY
         _email_server = SMTP_SSL(
-            EmailNotifications.email_smtp_server,
-            EmailNotifications.email_smtp_server_port,
+            self.email_smtp_server,
+            self.email_smtp_server_port,
         )
         _email_server.ehlo()
         _email_server.login(
-            user=EmailNotifications.email_username,
-            password=EmailNotifications._email_password,
+            user=self.email_username,
+            password=self._email_password,
         )
         _email_server.quit()
 
-    def __repr__(self):
-        """
-        String Representation
-        """
-        return "<EmailNotifications>"
-
-    @staticmethod
-    def send_message(message: str, **kwargs) -> object:
+    def send_message(self, message: str, **kwargs) -> None:
         """
         Send a message via Email
 
@@ -89,30 +83,22 @@ class EmailNotifications(BaseNotifications):
         """
         email = EmailMessage()
         email.set_content(message)
-        email["Subject"] = kwargs.get("subject", EmailNotifications.email_subject)
-        email["From"] = kwargs.get("from", EmailNotifications.email_from)
-        email["To"] = kwargs.get("to", EmailNotifications.email_to)
-        email_server_user = kwargs.get("username", EmailNotifications.email_username)
-        email_server_password = kwargs.get(
-            "password", EmailNotifications._email_password
-        )
-        email_server_smtp_server = kwargs.get(
-            "server", EmailNotifications.email_smtp_server
-        )
-        email_server_smtp_server_port = kwargs.get(
-            "port", EmailNotifications.email_smtp_server_port
-        )
+        email["Subject"] = kwargs.get("subject", self.email_subject)
+        email["From"] = kwargs.get("from", self.email_from)
+        email["To"] = kwargs.get("to", self.email_to)
+        email_server_user = kwargs.get("username", self.email_username)
+        email_server_password = kwargs.get("password", self._email_password)
+        email_server_smtp_server = kwargs.get("server", self.email_smtp_server)
+        email_server_smtp_server_port = kwargs.get("port", self.email_smtp_server_port)
         email_server = SMTP_SSL(email_server_smtp_server, email_server_smtp_server_port)
         email_server.ehlo()
         email_server.login(user=email_server_user, password=email_server_password)
         logger.info(f"Sending Email to {email['To']}: {email['Subject']}")
-        response = email_server.send_message(email)
+        email_server.send_message(email)
         logger.info("Email sent successfully")
         email_server.quit()
-        return response
 
-    @classmethod
-    def send_campsites(cls, campsites: List[AvailableCampsite], **kwargs) -> None:
+    def send_campsites(self, campsites: List[AvailableCampsite], **kwargs) -> None:
         """
         Send a message with a campsite object
 
@@ -122,7 +108,7 @@ class EmailNotifications(BaseNotifications):
         """
         master_email_body_list = list()
         for campsite in campsites:
-            message_title, formatted_dict = cls.format_standard_campsites(
+            message_title, formatted_dict = self.format_standard_campsites(
                 campsite=campsite,
             )
             fields = [message_title]
@@ -134,4 +120,4 @@ class EmailNotifications(BaseNotifications):
             master_email_body_list.append(composed_message)
         master_email_body = "\n".join(master_email_body_list)
         if len(campsites) > 0:
-            EmailNotifications.send_message(message=master_email_body)
+            self.send_message(message=master_email_body)

--- a/camply/notifications/multi_provider_notifications.py
+++ b/camply/notifications/multi_provider_notifications.py
@@ -43,6 +43,7 @@ class MultiNotifierProvider(BaseNotifications):
             Provider String, Comma Separated Provider String, or list of provider
             strings
         """
+        super().__init__()
         self.providers = [SilentNotifications()]
         if isinstance(provider, str):
             provider = [prov_string.strip() for prov_string in provider.split(",")]

--- a/camply/notifications/pushbullet.py
+++ b/camply/notifications/pushbullet.py
@@ -20,6 +20,10 @@ class PushbulletNotifications(BaseNotifications):
     """
 
     def __init__(self):
+        super().__init__()
+        pushbullet_headers = PushbulletConfig.API_HEADERS.copy()
+        pushbullet_headers.update({"Access-Token": PushbulletConfig.API_TOKEN})
+        self.session.headers.update(pushbullet_headers)
         if any([PushbulletConfig.API_TOKEN is None, PushbulletConfig.API_TOKEN == ""]):
             warning_message = (
                 "Pushbullet is not configured properly. To send Pushbullet messages "
@@ -29,14 +33,7 @@ class PushbulletNotifications(BaseNotifications):
             logger.error(warning_message)
             raise EnvironmentError(warning_message)
 
-    def __repr__(self):
-        """
-        String Representation
-        """
-        return "<PushbulletNotifications>"
-
-    @staticmethod
-    def send_message(message: str, **kwargs) -> requests.Response:
+    def send_message(self, message: str, **kwargs) -> requests.Response:
         """
         Send a message via PushBullet - if environment variables are configured
 
@@ -48,17 +45,14 @@ class PushbulletNotifications(BaseNotifications):
         -------
         requests.Response
         """
-        pushbullet_headers = PushbulletConfig.API_HEADERS.copy()
-        pushbullet_headers.update({"Access-Token": PushbulletConfig.API_TOKEN})
         message_type = kwargs.pop("type", "note")
         message_title = kwargs.pop("title", "Camply Notification")
         message_json = dict(
             type=message_type, title=message_title, body=message, **kwargs
         )
         logger.debug(message_json)
-        response = requests.post(
+        response = self.session.post(
             url=PushbulletConfig.PUSHBULLET_API_ENDPOINT,
-            headers=pushbullet_headers,
             json=message_json,
         )
         try:
@@ -71,8 +65,7 @@ class PushbulletNotifications(BaseNotifications):
             raise ConnectionError(response.text) from he
         return response
 
-    @classmethod
-    def send_campsites(cls, campsites: List[AvailableCampsite], **kwargs):
+    def send_campsites(self, campsites: List[AvailableCampsite], **kwargs):
         """
         Send a message with a campsite object
 
@@ -81,13 +74,13 @@ class PushbulletNotifications(BaseNotifications):
         campsites: AvailableCampsite
         """
         for campsite in campsites:
-            message_title, formatted_dict = cls.format_standard_campsites(
+            message_title, formatted_dict = self.format_standard_campsites(
                 campsite=campsite,
             )
             fields = []
             for key, value in formatted_dict.items():
                 fields.append(f"{key}: {value}")
             composed_message = "\n".join(fields)
-            PushbulletNotifications.send_message(
+            self.send_message(
                 message=composed_message, title=message_title, type="note"
             )

--- a/camply/notifications/silent_notifications.py
+++ b/camply/notifications/silent_notifications.py
@@ -17,14 +17,7 @@ class SilentNotifications(BaseNotifications):
     Silent Notifications
     """
 
-    def __repr__(self):
-        """
-        String Representation
-        """
-        return "<SilentNotifications>"
-
-    @staticmethod
-    def send_message(message: Iterable, **kwargs) -> None:
+    def send_message(self, message: Iterable, **kwargs) -> None:
         """
         Send a message via Email
 
@@ -42,8 +35,7 @@ class SilentNotifications(BaseNotifications):
         message_string = "\n\t• " + "\n\t• ".join(list(message))
         logger.debug(f"SilentNotification: {message_string}")
 
-    @staticmethod
-    def send_campsites(campsites: List[AvailableCampsite], **kwargs):
+    def send_campsites(self, campsites: List[AvailableCampsite], **kwargs):
         """
         Send a message with a campsite object
 
@@ -63,6 +55,6 @@ class SilentNotifications(BaseNotifications):
                 campsite.facility_name,
                 campsite.booking_url,
             )
-            SilentNotifications.send_message(campsite_tuple)
+            self.send_message(campsite_tuple)
             campsite_formatted = pformat(campsite.dict())
             logger.debug("Campsite Info: " + campsite_formatted)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ flake8 = { version = ">=3.0.0", optional = true }
 coverage = { version = ">=6.2", extras = ["toml"], optional = true }
 mypy = { version = "^0.971", optional = true }
 tox = { version = "^3.25.1", optional = true }
-twilio = { version = ">=7.14.0", optional=true}
+twilio = { version = ">=7.14.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = ">=5.2"
@@ -65,6 +65,9 @@ dev = [
     "twilio"
 ]
 twilio = [
+    "twilio"
+]
+all = [
     "twilio"
 ]
 


### PR DESCRIPTION
# Description

This PR cleans up the notification Providers. It converst the ClassMethod / StaticMethod AbstractMethods into InstanceMethods, removes the per-class __repr__, and adds a little camply branding to SMS text messages. It 


# Has This Been Tested?

I ran this locally on multiple providers.


# Checklist:

- [x] I've read the contributing guidelines of this project
- [x] I've added a `BUMP_MAJOR`, `BUMP_MINOR`, or `BUMP_PATCH` label to this PR to increment the version
- [x] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation
