### PR TITLE
Feature/offline storage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,8 @@ jobs:
                 -   {name: Python 3.9, python: '3.9', tox: py39}
                 -   {name: Python 3.8, python: '3.8', tox: py38}
                 -   {name: Python 3.7, python: '3.7', tox: py37}
+        env:
+            CAMPLY_LOG_HANDLER: PYTHON
         steps:
         -   name: Set up Github Workspace
             uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ ___________
         + [Look for a Campsite Across Multiple Recreation areas](#look-for-a-campsite-across-multiple-recreation-areas)
         + [Using a YAML Configuration file to search for campsites](#using-a-yaml-configuration-file-to-search-for-campsites)
         + [Searching for a Campsite That Fits Your Equipment](#searching-for-a-campsite-that-fits-your-equipment)
+        + [Saving the Results of a Search](#saving-the-results-of-a-search)
         + [Search for Recreation Areas by Query String](#search-for-recreation-areas-by-query-string)
         + [Look for Specific Campgrounds Within a Recreation Area](#look-for-specific-campgrounds-within-a-recreation-area)
         + [Look for Specific Campgrounds by Query String](#look-for-specific-campgrounds-by-query-string)
@@ -501,6 +502,8 @@ notifications:    email  # (silent, email, pushover, pushbullet, and telegram), 
 search_forever:   true  # FALSE BY DEFAULT
 notify_first_try: false  # FALSE BY DEFAULT
 equipment:        null # Array of Equipment Search Lists - DEFAULTS TO `null`
+offline_search: false    # FALSE BY DEFAULT
+offline_search_path: camply_campsites.json # Defaults to `camply_campsites.json`
 ```
 
 ```shell
@@ -550,6 +553,39 @@ camply campsites \
     --end-date 2023-07-17 \
     --nights 5 \
     --equipment Trailer 0
+```
+
+#### Saving the Results of a Search
+
+In some cases, you might want to save all the campsites found during one
+search and load them into a new search, so you don't receive duplicate notifications.
+This can be achieved by passing the `--offline-search` flag. By default, camply will save
+the results in a file called `camply_campsites.json`.
+
+Optionally, you can also path the `--offline-search-path` flag to specify a certain file
+path to save the results as. When a file path with a `.json` extension is passed
+camply will export the results as a JSON file. When the `.pkl` or `.pickle` extension is
+used, camply will use a serialized Pickle file.
+
+```shell
+camply \
+  campsites \
+  --campground 232064 \
+  --start-date 2023-09-01 \
+  --end-date 2023-10-01 \
+  --continuous \
+  --offline-search
+```
+
+```shell
+camply \
+  campsites \
+  --campground 232064 \
+  --start-date 2023-09-01 \
+  --end-date 2023-10-01 \
+  --continuous \
+  --offline-search \
+  --offline-search-path campsites.pkl
 ```
 
 #### Search for Recreation Areas by Query String

--- a/camply/cli.py
+++ b/camply/cli.py
@@ -268,15 +268,17 @@ offline_search_argument = click.option(
     show_default=True,
     default=False,
     help="When set to True, the campsite search will both save the results of the "
-    "campsites it's found, but also load those campsites before beginning a"
-    "search for other campsites. Campsites are saved as a serialized pickle file.",
+    "campsites it's found, but also load those campsites before beginning a "
+    "search for other campsites.",
 )
 offline_search_path_argument = click.option(
     "--offline-search-path",
     show_default=True,
     default=None,
     help="When offline search is set to True, this is the name of the file to be saved/loaded. "
-    " When not specified, the filename will default to `camply_campsites.pkl`",
+    "Campsites can be saved as a serialized pickle file or "
+    "a JSON file, depending on the file extension. When not specified, "
+    "the filename will default to `camply_campsites.json`",
 )
 
 

--- a/camply/cli.py
+++ b/camply/cli.py
@@ -262,6 +262,22 @@ equipment_argument = click.option(
     "equipment names include `Tent`, `RV`. `Trailer`, `Vehicle` and are "
     "not case-sensitive.",
 )
+offline_search_argument = click.option(
+    "--offline-search",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="When set to True, the campsite search will both save the results of the "
+    "campsites it's found, but also load those campsites before beginning a"
+    "search for other campsites. Campsites are saved as a serialized pickle file.",
+)
+offline_search_path_argument = click.option(
+    "--offline-search-path",
+    show_default=True,
+    default=None,
+    help="When offline search is set to True, this is the name of the file to be saved/loaded. "
+    " When not specified, the filename will default to `camply_campsites.pkl`",
+)
 
 
 def _get_equipment(equipment: Optional[List[str]]) -> List[Tuple[str, Optional[int]]]:
@@ -327,6 +343,8 @@ def _validate_campsites(
 
 
 @yaml_config_argument
+@offline_search_path_argument
+@offline_search_argument
 @search_forever_argument
 @notify_first_try_argument
 @notifications_argument
@@ -358,6 +376,8 @@ def campsites(
     search_forever: bool = False,
     yaml_config: Optional[str] = None,
     equipment: Optional[List[str]] = None,
+    offline_search: bool = False,
+    offline_search_path: Optional[str] = None,
 ) -> None:
     """
     Find available Campsites using search criteria
@@ -404,6 +424,8 @@ def campsites(
             weekends_only=weekends,
             nights=int(nights),
             equipment=make_list(equipment),
+            offline_search=offline_search,
+            offline_search_path=offline_search_path,
         )
         search_kwargs = dict(
             log=True,

--- a/camply/containers/base_container.py
+++ b/camply/containers/base_container.py
@@ -18,11 +18,8 @@ class CamplyModel(BaseModel):
         """
         Hash Method for Pydantic BaseModels
         """
-        values_to_hash = tuple(
-            getattr(self, key)
-            for key in self.__fields__
-            if key not in self.__unhashable__
-        )
+        fields_to_hash = sorted(list(set(self.__fields__) - set(self.__unhashable__)))
+        values_to_hash = tuple(getattr(self, key) for key in fields_to_hash)
         return hash((type(self),) + values_to_hash)
 
 

--- a/camply/containers/base_container.py
+++ b/camply/containers/base_container.py
@@ -22,6 +22,12 @@ class CamplyModel(BaseModel):
         values_to_hash = tuple(getattr(self, key) for key in fields_to_hash)
         return hash((type(self),) + values_to_hash)
 
+    def __eq__(self, other: Any) -> bool:
+        """
+        Use __hash__ to determine Equality
+        """
+        return hash(self) == hash(other)
+
 
 ############################
 # RecDotGov Base Containers

--- a/camply/containers/data_containers.py
+++ b/camply/containers/data_containers.py
@@ -63,7 +63,7 @@ class AvailableCampsite(CamplyModel):
     permitted_equipment: Optional[List[RecDotGovEquipment]]
     campsite_attributes: Optional[List[RecDotGovAttribute]]
 
-    __unhashable__ = ["permitted_equipment", "campsite_attributes"]
+    __unhashable__ = {"permitted_equipment", "campsite_attributes"}
 
 
 class CampgroundFacility(CamplyModel):

--- a/camply/search/base_search.py
+++ b/camply/search/base_search.py
@@ -529,11 +529,13 @@ class BaseCampingSearch(ABC):
                 search_forever=search_forever,
             )
         else:
+            starting_count = len(self.campsites_found)
             matching_campsites = self._search_matching_campsites_available(
                 log=log, verbose=True
             )
             self.campsites_found.update(set(matching_campsites))
-            if self.offline_search is True:
+            ending_count = len(self.campsites_found)
+            if self.offline_search is True and ending_count > starting_count:
                 self.unload_campsites_to_file()
         return list(self.campsites_found)
 

--- a/camply/search/base_search.py
+++ b/camply/search/base_search.py
@@ -229,7 +229,7 @@ class BaseCampingSearch(ABC):
             and raise_error is True
         ):
             campsite_availability_message = (
-                "No new Campsites were found, we'll continue checking"
+                "No New Campsites were found, we'll continue checking"
             )
             logger.info(campsite_availability_message)
             raise CampsiteNotFoundError(campsite_availability_message)
@@ -460,6 +460,7 @@ class BaseCampingSearch(ABC):
         continuous_search = True
         continuous_search_attempts = 1
         while continuous_search is True:
+            starting_count = len(self.campsites_found)
             self._continuous_search_retry(
                 log=log,
                 verbose=verbose,
@@ -468,8 +469,9 @@ class BaseCampingSearch(ABC):
                 notify_first_try=notify_first_try,
                 continuous_search_attempts=continuous_search_attempts,
             )
+            ending_count = len(self.campsites_found)
             continuous_search_attempts += 1
-            if self.offline_search is True:
+            if self.offline_search is True and ending_count > starting_count:
                 self.unload_campsites_to_file()
             if search_forever is True:
                 sleep(int(polling_interval_minutes) * 60)
@@ -672,9 +674,7 @@ class BaseCampingSearch(ABC):
         -------
         DataFrame
         """
-        duplicate_subset = set(dataframe.columns) - set(
-            AvailableCampsite.__unhashable__
-        )
+        duplicate_subset = set(dataframe.columns) - AvailableCampsite.__unhashable__
         dataframe_slice = dataframe.copy().reset_index(drop=True)
         nights_indexes = dataframe_slice.booking_date.index
         consecutive_generator = cls._consecutive_subseq(

--- a/camply/search/search_recreationdotgov.py
+++ b/camply/search/search_recreationdotgov.py
@@ -68,7 +68,7 @@ class SearchRecreationDotGov(BaseCampingSearch):
             search for other campsites.
         offline_search_path: Optional[str]
             When offline search is set to True, this is the name of the file to be saved/loaded.
-            When not specified, the filename will default to `camply_campsites.pkl`
+            When not specified, the filename will default to `camply_campsites.json`
         """
         self.campsite_finder: RecreationDotGov
         super(SearchRecreationDotGov, self).__init__(

--- a/camply/search/search_recreationdotgov.py
+++ b/camply/search/search_recreationdotgov.py
@@ -33,6 +33,8 @@ class SearchRecreationDotGov(BaseCampingSearch):
         weekends_only: bool = False,
         nights: int = 1,
         equipment: Optional[List[Tuple[str, Optional[int]]]] = None,
+        offline_search: bool = False,
+        offline_search_path: Optional[str] = None,
         **kwargs,
     ) -> None:
         """
@@ -60,6 +62,13 @@ class SearchRecreationDotGov(BaseCampingSearch):
             to 20 feet. Tuples contain the Equipment name and an optional equipment
             length, otherwise provide None. Equipment names include `Tent`, `RV`,
             `Trailer`, `Vehicle` and are not case-sensitive.
+        offline_search: bool
+            When set to True, the campsite search will both save the results of the
+            campsites it's found, but also load those campsites before beginning a
+            search for other campsites.
+        offline_search_path: Optional[str]
+            When offline search is set to True, this is the name of the file to be saved/loaded.
+            When not specified, the filename will default to `camply_campsites.pkl`
         """
         self.campsite_finder: RecreationDotGov
         super(SearchRecreationDotGov, self).__init__(
@@ -67,6 +76,8 @@ class SearchRecreationDotGov(BaseCampingSearch):
             search_window=search_window,
             weekends_only=weekends_only,
             nights=nights,
+            offline_search=offline_search,
+            offline_search_path=offline_search_path,
         )
         self._recreation_area_id = make_list(recreation_area)
         self._campground_object = campgrounds

--- a/camply/search/search_yellowstone.py
+++ b/camply/search/search_yellowstone.py
@@ -30,6 +30,8 @@ class SearchYellowstone(BaseCampingSearch):
         weekends_only: bool = False,
         campgrounds: Optional[Union[List[str], str]] = None,
         nights: int = 1,
+        offline_search: bool = False,
+        offline_search_path: Optional[str] = None,
         **kwargs,
     ) -> None:
         """
@@ -46,12 +48,21 @@ class SearchYellowstone(BaseCampingSearch):
             Campground ID or List of Campground IDs
         nights: int
             minimum number of consecutive nights to search per campsite,defaults to 1
+        offline_search: bool
+            When set to True, the campsite search will both save the results of the
+            campsites it's found, but also load those campsites before beginning a
+            search for other campsites.
+        offline_search_path: Optional[str]
+            When offline search is set to True, this is the name of the file to be saved/loaded.
+            When not specified, the filename will default to `camply_campsites.pkl`
         """
         super().__init__(
             provider=YellowstoneLodging(),
             search_window=search_window,
             weekends_only=weekends_only,
             nights=nights,
+            offline_search=offline_search,
+            offline_search_path=offline_search_path,
         )
         self.campgrounds = make_list(campgrounds)
 

--- a/camply/search/search_yellowstone.py
+++ b/camply/search/search_yellowstone.py
@@ -54,7 +54,7 @@ class SearchYellowstone(BaseCampingSearch):
             search for other campsites.
         offline_search_path: Optional[str]
             When offline search is set to True, this is the name of the file to be saved/loaded.
-            When not specified, the filename will default to `camply_campsites.pkl`
+            When not specified, the filename will default to `camply_campsites.json`
         """
         super().__init__(
             provider=YellowstoneLodging(),

--- a/camply/utils/yaml_utils.py
+++ b/camply/utils/yaml_utils.py
@@ -116,6 +116,8 @@ def yaml_file_to_arguments(
     equipment = make_list(equipment)
     if isinstance(equipment, list):
         equipment = [tuple(equip) for equip in equipment]
+    offline_search = yaml_search.get("offline_search", False)
+    offline_search_path = yaml_search.get("offline_search_path", None)
 
     search_window = SearchWindow(start_date=start_date, end_date=end_date)
 
@@ -127,6 +129,8 @@ def yaml_file_to_arguments(
         weekends_only=weekends_only,
         nights=nights,
         equipment=equipment,
+        offline_search=offline_search,
+        offline_search_path=offline_search_path,
     )
     search_kwargs = dict(
         log=True,

--- a/docs/examples/example_search.yaml
+++ b/docs/examples/example_search.yaml
@@ -14,3 +14,5 @@ notifications: email     # (silent, email, pushover, pushbullet, and telegram), 
 search_forever: true    # FALSE BY DEFAULT
 notify_first_try: false  # FALSE BY DEFAULT
 equipment:             # Array of Equipment Search Lists - DEFAULTS TO `null`
+offline_search: false    # FALSE BY DEFAULT
+offline_search_path: camply_campsites.json # Defaults to `camply_campsites.json`

--- a/tests/command_line_test.sh
+++ b/tests/command_line_test.sh
@@ -43,3 +43,34 @@ camply --debug campsites \
   --start-date 2023-10-01 \
   --end-date 2023-10-02 \
   --campground 234779
+
+camply \
+  --debug \
+  campsites \
+  --campground 232064 \
+  --start-date 2023-09-01 \
+  --end-date 2023-10-01 \
+  --offline-search \
+  --offline-search-path test_file.json
+
+rm test_file.json
+
+camply \
+  --debug \
+  campsites \
+  --campground 232064 \
+  --start-date 2023-09-01 \
+  --end-date 2023-10-01 \
+  --offline-search \
+  --offline-search-path file.pickle
+
+camply \
+  --debug \
+  campsites \
+  --campground 232064 \
+  --start-date 2023-09-01 \
+  --end-date 2023-10-01 \
+  --offline-search \
+  --offline-search-path test_file.pickle
+
+rm test_file.pickle

--- a/tests/command_line_test.sh
+++ b/tests/command_line_test.sh
@@ -2,47 +2,56 @@
 
 set -ex
 
-camply --debug recreation-areas --search "Yosemite National Park"
-camply --debug campgrounds --rec-area 2991
-camply --debug campgrounds --search "Fire Tower Lookout" --state CA
-camply --debug campsites --rec-area 2991 --start-date 2023-09-15 --end-date 2023-09-17
-camply --debug campsites --campground 252037 --start-date 2023-09-15 --end-date 2023-09-17
-camply --debug campsites --yaml-config tests/yaml/example_search.yaml
-camply --debug campsites --campground 232045 --start-date 2023-07-15 --end-date 2023-10-01 --nights 5
-camply --debug campsites --provider yellowstone --start-date 2023-10-10 --end-date 2023-10-16
-camply --debug campsites --campsite 40107 --start-date 2023-09-15 --end-date 2023-09-17
-camply --debug campgrounds --campsite 40107
-camply --debug campsites --yaml-config tests/yaml/example_campsite_search.yaml
+#camply --debug recreation-areas --search "Yosemite National Park"
+#camply --debug campgrounds --rec-area 2991
+#camply --debug campgrounds --search "Fire Tower Lookout" --state CA
+#camply --debug campsites --rec-area 2991 --start-date 2023-09-15 --end-date 2023-09-17
+#camply --debug campsites --campground 252037 --start-date 2023-09-15 --end-date 2023-09-17
+#camply --debug campsites --yaml-config tests/yaml/example_search.yaml
+#camply --debug campsites --campground 232045 --start-date 2023-07-15 --end-date 2023-10-01 --nights 5
+#camply --debug campsites --provider yellowstone --start-date 2023-10-10 --end-date 2023-10-16
+#camply --debug campsites --campsite 40107 --start-date 2023-09-15 --end-date 2023-09-17
+#camply --debug campgrounds --campsite 40107
+#camply --debug campsites --yaml-config tests/yaml/example_campsite_search.yaml
+#
+#camply \
+#  --debug \
+#  campsites \
+#  --provider yellowstone \
+#  --start-date 2023-09-01 \
+#  --end-date 2023-09-14 \
+#  --campground YLYF:RV
+#
+#camply \
+#    --debug \
+#    campsites \
+#    --rec-area 2018 \
+#    --start-date 2023-09-09 \
+#    --end-date 2023-09-17 \
+#    --nights 3 \
+#    --equipment RV 25
+#
+#camply \
+#  --debug \
+#  campsites \
+#  --campsite 84865 \
+#  --campsite 84001 \
+#  --start-date 2023-09-27 \
+#  --end-date 2023-09-28
+#
+#camply --debug campsites \
+#  --start-date 2023-10-01 \
+#  --end-date 2023-10-02 \
+#  --campground 234779
 
 camply \
   --debug \
   campsites \
-  --provider yellowstone \
+  --campground 232064 \
   --start-date 2023-09-01 \
-  --end-date 2023-09-14 \
-  --campground YLYF:RV
-
-camply \
-    --debug \
-    campsites \
-    --rec-area 2018 \
-    --start-date 2023-09-09 \
-    --end-date 2023-09-17 \
-    --nights 3 \
-    --equipment RV 25
-
-camply \
-  --debug \
-  campsites \
-  --campsite 84865 \
-  --campsite 84001 \
-  --start-date 2023-09-27 \
-  --end-date 2023-09-28
-
-camply --debug campsites \
-  --start-date 2023-10-01 \
-  --end-date 2023-10-02 \
-  --campground 234779
+  --end-date 2023-10-01 \
+  --offline-search \
+  --offline-search-path test_file.json
 
 camply \
   --debug \
@@ -62,7 +71,7 @@ camply \
   --start-date 2023-09-01 \
   --end-date 2023-10-01 \
   --offline-search \
-  --offline-search-path file.pickle
+  --offline-search-path test_file.pickle
 
 camply \
   --debug \

--- a/tests/command_line_test.sh
+++ b/tests/command_line_test.sh
@@ -2,47 +2,47 @@
 
 set -ex
 
-#camply --debug recreation-areas --search "Yosemite National Park"
-#camply --debug campgrounds --rec-area 2991
-#camply --debug campgrounds --search "Fire Tower Lookout" --state CA
-#camply --debug campsites --rec-area 2991 --start-date 2023-09-15 --end-date 2023-09-17
-#camply --debug campsites --campground 252037 --start-date 2023-09-15 --end-date 2023-09-17
-#camply --debug campsites --yaml-config tests/yaml/example_search.yaml
-#camply --debug campsites --campground 232045 --start-date 2023-07-15 --end-date 2023-10-01 --nights 5
-#camply --debug campsites --provider yellowstone --start-date 2023-10-10 --end-date 2023-10-16
-#camply --debug campsites --campsite 40107 --start-date 2023-09-15 --end-date 2023-09-17
-#camply --debug campgrounds --campsite 40107
-#camply --debug campsites --yaml-config tests/yaml/example_campsite_search.yaml
-#
-#camply \
-#  --debug \
-#  campsites \
-#  --provider yellowstone \
-#  --start-date 2023-09-01 \
-#  --end-date 2023-09-14 \
-#  --campground YLYF:RV
-#
-#camply \
-#    --debug \
-#    campsites \
-#    --rec-area 2018 \
-#    --start-date 2023-09-09 \
-#    --end-date 2023-09-17 \
-#    --nights 3 \
-#    --equipment RV 25
-#
-#camply \
-#  --debug \
-#  campsites \
-#  --campsite 84865 \
-#  --campsite 84001 \
-#  --start-date 2023-09-27 \
-#  --end-date 2023-09-28
-#
-#camply --debug campsites \
-#  --start-date 2023-10-01 \
-#  --end-date 2023-10-02 \
-#  --campground 234779
+camply --debug recreation-areas --search "Yosemite National Park"
+camply --debug campgrounds --rec-area 2991
+camply --debug campgrounds --search "Fire Tower Lookout" --state CA
+camply --debug campsites --rec-area 2991 --start-date 2023-09-15 --end-date 2023-09-17
+camply --debug campsites --campground 252037 --start-date 2023-09-15 --end-date 2023-09-17
+camply --debug campsites --yaml-config tests/yaml/example_search.yaml
+camply --debug campsites --campground 232045 --start-date 2023-07-15 --end-date 2023-10-01 --nights 5
+camply --debug campsites --provider yellowstone --start-date 2023-10-10 --end-date 2023-10-16
+camply --debug campsites --campsite 40107 --start-date 2023-09-15 --end-date 2023-09-17
+camply --debug campgrounds --campsite 40107
+camply --debug campsites --yaml-config tests/yaml/example_campsite_search.yaml
+
+camply \
+  --debug \
+  campsites \
+  --provider yellowstone \
+  --start-date 2023-09-01 \
+  --end-date 2023-09-14 \
+  --campground YLYF:RV
+
+camply \
+    --debug \
+    campsites \
+    --rec-area 2018 \
+    --start-date 2023-09-09 \
+    --end-date 2023-09-17 \
+    --nights 3 \
+    --equipment RV 25
+
+camply \
+  --debug \
+  campsites \
+  --campsite 84865 \
+  --campsite 84001 \
+  --start-date 2023-09-27 \
+  --end-date 2023-09-28
+
+camply --debug campsites \
+  --start-date 2023-10-01 \
+  --end-date 2023-10-02 \
+  --campground 234779
 
 camply \
   --debug \

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ isolated_build = true
 changedir = {toxinidir}/tests
 extras =
     dev
+passenv =
+    CAMPLY_LOG_HANDLER
 commands =
     ;FLAKE8 SYNTAX CHECK
     flake8 {toxinidir}/camply {toxinidir}/tests --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
# Description

This PR enables saving found campsites in persisted offline files (currently it works with `.json` and `.pickle` files). Subsequently, these saved files can be loaded into new searches. 

The primary use case for this is being able to stop and restart a campsite search without all notifications being resent. 

# Has This Been Tested?

A bit

# Checklist:

- [x] I've read the contributing guidelines of this project
- [x] I've added a `BUMP_MAJOR`, `BUMP_MINOR`, or `BUMP_PATCH` label to this PR to increment the version
- [x] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation
