### PR TITLE
Docker: Use Lock File

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,36 @@
-FROM python:3.9-slim
+FROM python:3.9-slim as python-base
+
+FROM python-base as builder
+
+ENV POETRY_VERSION=1.2.1
+RUN python -m pip install --upgrade pip wheel
+RUN python -m pip install poetry==${POETRY_VERSION}
+
+COPY poetry.lock /tmp/camply/poetry.lock
+COPY pyproject.toml /tmp/camply/pyproject.toml
+COPY README.md /tmp/camply/README.md
+COPY camply/ /tmp/camply/camply/
+
+RUN cd /tmp/camply/ && poetry export -f requirements.txt --ansi --without-hashes --extras all -o /tmp/camply/requirements.txt
+
+FROM python-base as final
 
 MAINTAINER Justin Flannery <juftin@juftin.com>
 LABEL description="camply, the campsite finder"
 
-COPY pyproject.toml /tmp/camply/pyproject.toml
-COPY camply/ /tmp/camply/camply/
-COPY README.md /tmp/camply/README.md
-RUN cd /tmp/camply/ && python -m pip install "/tmp/camply/[all]" && rm -rf /tmp/camply/
+COPY --from=builder /tmp/camply/ /tmp/camply/
 
-ENV HOME=/home/camply
-RUN mkdir ${HOME}
-WORKDIR ${HOME}
+RUN python -m pip install -r /tmp/camply/requirements.txt && \
+    python -m pip install /tmp/camply --no-dependencies && \
+    rm -rf /tmp/camply/
+
+RUN mkdir /home/camply
+WORKDIR /home/camply
 ENV CAMPLY_LOG_HANDLER="PYTHON"
 
-CMD camply
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN _CAMPLY_COMPLETE=bash_source camply > /root/.camply-complete.bash && \
+    echo "[[ ! -f /root/.camply-complete.bash ]] || source /root/.camply-complete.bash" >> /root/.bashrc
+
+CMD ["camply", "--help"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,12 +1,11 @@
 [extras]
 all = ["twilio"]
-dev = ["pytest", "flake8", "coverage", "mypy", "tox", "twilio"]
 twilio = ["twilio"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<4.0"
-content-hash = "404ba3cdec0292f465ae56b9c1c8b63b5de254f6c812a2c4fa11f184721ba539"
+content-hash = "c6733ec74ac687ffe631fcaec78d0fd23aecb15e0bae6ea736b0cc00e8376ebf"
 
 [metadata.files]
 attrs = [
@@ -430,7 +429,7 @@ zipp = [
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
 
@@ -494,7 +493,7 @@ test = ["hypothesis (==3.55.3)", "flake8 (==3.7.8)"]
 name = "coverage"
 version = "6.5.0"
 description = "Code coverage measurement for Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -508,7 +507,7 @@ toml = ["tomli"]
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -516,7 +515,7 @@ python-versions = "*"
 name = "filelock"
 version = "3.8.0"
 description = "A platform independent file lock."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -528,7 +527,7 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pyt
 name = "flake8"
 version = "5.0.4"
 description = "the modular source code checker: pep8 pyflakes and co"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6.1"
 
@@ -566,7 +565,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -574,7 +573,7 @@ python-versions = "*"
 name = "mccabe"
 version = "0.7.0"
 description = "McCabe checker, plugin for flake8"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -582,7 +581,7 @@ python-versions = ">=3.6"
 name = "mypy"
 version = "0.971"
 description = "Optional static typing for Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -601,7 +600,7 @@ reports = ["lxml"]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -625,7 +624,7 @@ python-versions = ">=3.8"
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -657,7 +656,7 @@ test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
 name = "platformdirs"
 version = "2.5.2"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -669,7 +668,7 @@ test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytes
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -684,7 +683,7 @@ dev = ["tox", "pre-commit"]
 name = "py"
 version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -692,7 +691,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "pycodestyle"
 version = "2.9.1"
 description = "Python style guide checker"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -715,7 +714,7 @@ email = ["email-validator (>=1.0.3)"]
 name = "pyflakes"
 version = "2.5.0"
 description = "passive checker of Python programs"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -748,7 +747,7 @@ tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 name = "pyparsing"
 version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6.8"
 
@@ -759,7 +758,7 @@ diagrams = ["railroad-diagrams", "jinja2"]
 name = "pytest"
 version = "7.1.3"
 description = "pytest: simple powerful testing with Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -871,7 +870,7 @@ doc = ["reno", "sphinx", "tornado (>=4.5)"]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -879,7 +878,7 @@ python-versions = ">=3.7"
 name = "tox"
 version = "3.26.0"
 description = "tox is a generic virtualenv management and test command line tool"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
@@ -915,7 +914,7 @@ requests = ">=2.0.0"
 name = "typed-ast"
 version = "1.5.4"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -944,7 +943,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 name = "virtualenv"
 version = "20.16.2"
 description = "Virtual Python Environment builder"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,6 @@ tenacity = ">=5.1.0"
 pydantic = ">=1.2,<2.0"
 click = ">=8.0.1"
 rich = ">=10.0.0"
-pytest = { version = ">=6.2.5", optional = true }
-flake8 = { version = ">=3.0.0", optional = true }
-coverage = { version = ">=6.2", extras = ["toml"], optional = true }
-mypy = { version = "^0.971", optional = true }
-tox = { version = "^3.25.1", optional = true }
 twilio = { version = ">=7.14.0", optional = true }
 
 [tool.poetry.dev-dependencies]
@@ -56,14 +51,6 @@ tox = "^3.25.1"
 mypy = "^0.971"
 
 [tool.poetry.extras]
-dev = [
-    "pytest",
-    "flake8",
-    "coverage",
-    "mypy",
-    "tox",
-    "twilio"
-]
 twilio = [
     "twilio"
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,13 @@ isolated_build = true
 
 [testenv]
 changedir = {toxinidir}/tests
-extras =
-    dev
+deps =
+    pytest>=5.2
+    coverage[toml]>=6.2
+    flake8>=3.0.0
+    mypy>=0.971
+passenv =
+    CAMPLY_LOG_HANDLER
 commands =
     ;FLAKE8 SYNTAX CHECK
     flake8 {toxinidir}/camply {toxinidir}/tests --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
# Description

This PR uses the Poetry Lock File when installing dependencies into the Docker image. It also installs Shell Completion and removes the testing "dev" extras.

# Has This Been Tested?

Yesh

# Checklist:

- [x] I've read the contributing guidelines of this project
- [x] I've added a `BUMP_MAJOR`, `BUMP_MINOR`, or `BUMP_PATCH` label to this PR to increment the version
- [x] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation
