### PR TITLE
🐛 SilentNotifications.send_message BugFix

### DIFF
--- a/camply/notifications/silent_notifications.py
+++ b/camply/notifications/silent_notifications.py
@@ -17,13 +17,13 @@ class SilentNotifications(BaseNotifications):
     Silent Notifications
     """
 
-    def send_message(self, message: Iterable, **kwargs) -> None:
+    def send_message(self, message: str, **kwargs) -> None:
         """
         Send a message via Email
 
         Parameters
         ----------
-        message: Iterable
+        message: str
             Email Body
         **kwargs
             kwargs are disregarded
@@ -32,8 +32,7 @@ class SilentNotifications(BaseNotifications):
         -------
         None
         """
-        message_string = "\n\t• " + "\n\t• ".join(list(message))
-        logger.debug(f"SilentNotification: {message_string}")
+        logger.debug(f"SilentNotification: {message}")
 
     def send_campsites(self, campsites: List[AvailableCampsite], **kwargs):
         """
@@ -55,6 +54,7 @@ class SilentNotifications(BaseNotifications):
                 campsite.facility_name,
                 campsite.booking_url,
             )
-            self.send_message(campsite_tuple)
+            message_string = "\n\t• " + "\n\t• ".join(campsite_tuple)
+            self.send_message(message_string)
             campsite_formatted = pformat(campsite.dict())
             logger.debug("Campsite Info: " + campsite_formatted)


### PR DESCRIPTION
It currently breaks a message into characters and puts them in a bullet list, specifically for notifier.send_message() calls in base_search.py.

# Description

[//]: # (Please include a summary of the changes and a link/description of the related issue.)
[//]: # (Please also include relevant motivation and context.)


# Has This Been Tested?

[//]: # (Please describe the tests that you ran to verify your changes. Provide instructions to reproduce.)
[//]: # (Please also list any relevant details for your test configuration)


# Checklist:

- [ ] I've read the contributing guidelines of this project
- [ ] I've added a `BUMP_MAJOR`, `BUMP_MINOR`, or `BUMP_PATCH` label to this PR to increment the version
- [ ] I've installed and used `.pre_commit` on all my code
- [ ] I have documented my code, particularly in hard-to-understand areas
- [ ] I have made any necessary corresponding changes to the documentation
