### PR TITLE
📝 CLI Documentation Formatting

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,9 +1,13 @@
 name: Documentation
 
 on:
-    release:
-        types:
-        -   released
+    push:
+        branches: ['main']
+        paths:
+        -   camply/**
+        -   docs/**
+        -   .github/workflows/docs.yaml
+        -   mkdocs.yml
 
 jobs:
     github-pages-publish:

--- a/camply/cli.py
+++ b/camply/cli.py
@@ -415,14 +415,11 @@ equipment_argument = click.option(
 equipment_id_argument = click.option(
     "--equipment-id",
     default=None,
-    help="""
-    Search for campsites campaitble with specific equipment categories. Going To
-    Camp uses equipment category IDs for filtering campsites by equipment. Every
-    recreation area has equipment categories unique to it.
-
-    Use `camply equipment-types --provider goingtocamp --rec-area <rec area id>`
-    to get a listing of equipment for an area.
-    """,
+    help="Search for campsites campaitble with specific equipment categories. Going To "
+    "Camp uses equipment category IDs for filtering campsites by equipment. Every "
+    "recreation area has equipment categories unique to it."
+    "Use `camply equipment-types --provider goingtocamp --rec-area <rec area id>` "
+    "to get a listing of equipment for an area.",
 )
 
 offline_search_argument = click.option(

--- a/camply/cli.py
+++ b/camply/cli.py
@@ -417,7 +417,7 @@ equipment_id_argument = click.option(
     default=None,
     help="Search for campsites campaitble with specific equipment categories. Going To "
     "Camp uses equipment category IDs for filtering campsites by equipment. Every "
-    "recreation area has equipment categories unique to it."
+    "recreation area has equipment categories unique to it. "
     "Use `camply equipment-types --provider goingtocamp --rec-area <rec area id>` "
     "to get a listing of equipment for an area.",
 )


### PR DESCRIPTION

# Description

[//]: # Changed triple quotes to single quotes for help text in `--equipment-id` in `cli.py`. This now matches other help texts spanning multiple lines, and should fix the issue with compiling the options into a table.
[//]: # The options in the  [CLI documentation](https://juftin.com/camply/cli/#documentation) under "Campsites" does not compile correctly: from `--equipment-id` onwards, the table seems to break. This change hopefully fixes that issue and puts everything into their appropriate table.


# Has This Been Tested?

[//]: # Unfortunately, I couldn't quite figure out how to compile the documentation on my own system, so that hasn't been tested yet. Happy to do so if the maintainers give me a pointer for how to compile the documentation. :) 


# Checklist:

- [x ] I've read the [contributing guidelines](https://juftin.com/camply/contributing) of this project
- [ x] I've installed and used `.pre_commit` on all my code
- [ x] I have documented my code, particularly in hard-to-understand areas
- [ x] I have made any necessary corresponding changes to the documentation
