### PR TITLE
:bug: Remove defunct GTC recreation areas

### DIFF
--- a/camply/providers/going_to_camp/going_to_camp_provider.py
+++ b/camply/providers/going_to_camp/going_to_camp_provider.py
@@ -38,64 +38,49 @@ RECREATION_AREAS = {
         recreation_area_id=3,
         recreation_area_location="Washington, USA",
     ),
-    "yukon.goingtocamp.com": RecreationArea(
-        recreation_area="Yukon (Backcountry)",
-        recreation_area_id=4,
-        recreation_area_location="Yukon, CA",
-    ),
-    "hamilton.goingtocamp.com": RecreationArea(
-        recreation_area="Hamilton",
-        recreation_area_id=5,
-        recreation_area_location="Ontario, CA",
-    ),
     "maitlandvalley.goingtocamp.com": RecreationArea(
         recreation_area="Maitland Valley",
-        recreation_area_id=6,
+        recreation_area_id=4,
         recreation_area_location="Ontario, CA",
-    ),
-    "orovillepark.goingtocamp.com": RecreationArea(
-        recreation_area="Oroville Park",
-        recreation_area_id=7,
-        recreation_area_location="Washington, USA",
     ),
     "saugeen.goingtocamp.com": RecreationArea(
         recreation_area="Saugeen Valley",
-        recreation_area_id=8,
+        recreation_area_id=5,
         recreation_area_location="Ontario, CA",
     ),
     "tacomapower.goingtocamp.com": RecreationArea(
         recreation_area="Tacoma Power Parks",
-        recreation_area_id=9,
+        recreation_area_id=6,
         recreation_area_location="Washington, USA",
     ),
     "wisconsin.goingtocamp.com": RecreationArea(
         recreation_area="Wisconsin State Parks",
-        recreation_area_id=10,
+        recreation_area_id=7,
         recreation_area_location="Wisconsin, USA",
     ),
     "ahtrails.ca": RecreationArea(
         recreation_area="Algonquin Highlands",
-        recreation_area_id=11,
+        recreation_area_id=8,
         recreation_area_location="Ontario, CA",
     ),
     "parkreservations.maryland.gov": RecreationArea(
         recreation_area="Maryland State Parks",
-        recreation_area_id=12,
+        recreation_area_id=9,
         recreation_area_location="Maryland, USA",
     ),
     "reservations.ncc-ccn.gc.ca": RecreationArea(
         recreation_area="Gatineau Park",
-        recreation_area_id=13,
+        recreation_area_id=10,
         recreation_area_location="Ottawa-Gatineau, Ontario-Quebec, CA",
     ),
     "www.nlcamping.ca": RecreationArea(
         recreation_area="Newfoundland & Labrador Provincial Parks",
-        recreation_area_id=14,
+        recreation_area_id=11,
         recreation_area_location="Newfoundland and Labrador, CA",
     ),
     "camping.bcparks.ca": RecreationArea(
         recreation_area="BC Parks",
-        recreation_area_id=15,
+        recreation_area_id=12,
         recreation_area_location="British Columbia, CA",
     ),
 }

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -59,24 +59,20 @@ to filter searches by recreation area when using GoingToCamp.
 
 The GoingToCamp Provider currently contains the following Recreation Areas:
 
--   Algonquin Highlands, Ontario, CA (#11)
--   BC Parks, British Columbia, CA (#15)
--   Gatineau Park, Ottawa-Gatineau, Ontario-Quebec, CA (#13)
--   Hamilton, Ontario, CA (#5)
+-   Algonquin Highlands, Ontario, CA (#8)
+-   BC Parks, British Columbia, CA (#12)
+-   Gatineau Park, Ottawa-Gatineau, Ontario-Quebec, CA (#10)
 -   Long Point Region, Ontario, CA (#1)
--   Maitland Valley, Ontario, CA (#6)
--   Maryland State Parks, Maryland, USA (#12)
--   Newfoundland & Labrador Provincial Parks, Newfoundland and Labrador, CA (#14)
--   Oroville Park, Washington, USA (#7)
--   Saugeen Valley, Ontario, CA (#8)
+-   Maitland Valley, Ontario, CA (#4)
+-   Maryland State Parks, Maryland, USA (#9)
+-   Newfoundland & Labrador Provincial Parks, Newfoundland and Labrador, CA (#11)
+-   Saugeen Valley, Ontario, CA (#5)
 -   St. Clair Region, Ontario, CA (#2)
--   Tacoma Power Parks, Washington, USA (#9)
+-   Tacoma Power Parks, Washington, USA (#6)
 -   Washington State Parks, Washington, USA (#3)
--   Wisconsin State Parks, Wisconsin, USA (#10)
--   Yukon (Backcountry), Yukon, CA (#4)
+-   Wisconsin State Parks, Wisconsin, USA (#7)
 
-Check out the following documentation examples for more details on searching GoingToCamp recreation
-areas:
+Check out the following documentation examples for more details on searching GoingToCamp recreation areas:
 
 -   [Look for a Campsite from GoingToCamp](command_line_usage.md#look-for-a-campsite-from-goingtocamp)
 -   [Searching GoingToCamp Using Equipment](command_line_usage.md#searching-goingtocamp-using-equipment)


### PR DESCRIPTION
# Description

Oroville, Hamilton, and Yukon recreation areas appear to no longer be GoingToCamp customers and their sites are down.


# Has This Been Tested?

Yes -- a campground list was performed on all remaining GTC recreation areas. 


# Checklist:

- [x] I've read the [contributing guidelines](https://juftin.com/camply/contributing) of this project
- [x] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation
