### PR TITLE
🐛 Specify utf-8 webhook encoding

### DIFF
--- a/camply/notifications/webhook.py
+++ b/camply/notifications/webhook.py
@@ -51,7 +51,7 @@ class WebhookNotifications(BaseNotifications):
         -------
         requests.Response
         """
-        response = self.session.post(url=self.webhook_url, data=message)
+        response = self.session.post(url=self.webhook_url, data=message.encode("utf-8"))
         try:
             response.raise_for_status()
         except requests.HTTPError as he:


### PR DESCRIPTION
# Description
Fixes https://github.com/juftin/camply/issues/302

[//]: # (Please include a summary of the changes and a link/description of the related issue.)
[//]: # (Please also include relevant motivation and context.)

Specify utf-8 body encoding on webhook requests. The emojis in campsites json body cannot be encoded with latin-1 encoding and ``camply`` crashes. The utf-8 encoding is [the json spec character encoding](https://www.rfc-editor.org/rfc/rfc8259), so it seems like an OK default stance for ``camply`` to take.

> JSON text exchanged between systems that are not part of a closed ecosystem MUST be encoded using UTF-8

Before
```bash
 WEBHOOK_URL="http://localhost:8000" camply campsites --campground 233998 --start-date 2023-10-10 --end-date 2023-10-21  --notifications webhook
```

..would crash with 

```
RuntimeError: camply encountered an error and exited 😟 [2023-09-14 22:13:53] - (UnicodeEncodeError) 'latin-1' codec
can't encode character '\U0001f3d5' in position 161: Body ('🏕') is not valid Latin-1. Use body.encode('utf-8') if you
want to send it encoded in UTF-8.
```

# Has This Been Tested?

[//]: # (Please describe the tests that you ran to verify your changes. Provide instructions to reproduce.)
[//]: # (Please also list any relevant details for your test configuration)


In background shell, start a simple webhook handler

```
from http.server import BaseHTTPRequestHandler, HTTPServer
import socketserver

class PostHandler(BaseHTTPRequestHandler):
    def do_POST(self):
        print('request')
        content_length = int(self.headers['Content-Length'])
        post_data = self.rfile.read(content_length)
        print(post_data.decode('utf-8'))

        self.send_response(200)
        self.end_headers()
        self.wfile.write(b'OK')

if __name__ == "__main__":
    PORT = 8000
    with HTTPServer(("", PORT), PostHandler) as httpd:
        print("serving at port", PORT)
        httpd.serve_forever()
```


```
(camply) (base) zach@z-pc:~/src/camply$ git log --oneline | head -n 1
f3b51ae 🐛 Specify utf-8 webhook encoding
```
then run:

```bash
(camply) (base) zach@z-pc:~/src/camply$ hatch shell
```


```bash
(camply) (base) zach@z-pc:~/src/camply$ WEBHOOK_URL="http://localhost:8000" camply campsites --campground 233998 --start-date 2023-10-10 --end-date 2023-10-21  --notifications webhook
```


..and the webhook handler prints:

```
127.0.0.1 - - [14/Sep/2023 22:17:15] "POST / HTTP/1.1" 200 -
request
{"campsites": [{"campsite_id": 76540, "booking_date": "2023-10-12T00:00:00",
......
```

..also, 

```bash
(camply) (base) zach@z-pc:~/src/camply$ hatch run all
...
-------------------------------------------------------------------------------------------------------
TOTAL                                                        3895    627    956    139    81%

...
108 passed in 30.67s 
...
```

# Checklist:

- [x] I've read the [contributing guidelines](https://juftin.com/camply/contributing) of this project
- [x] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation (none needed, I think utf8 for json is well understood)




(also, this is the first GitHub PR I've ever made, so apologies if something's not quite right).