### PR TITLE
Clarify weekends usage in example_search.yaml

### DIFF
--- a/docs/examples/example_search.yaml
+++ b/docs/examples/example_search.yaml
@@ -7,7 +7,7 @@ campsites: # OVERRIDES CAMPGROUNDS / RECREATION AREA - (LIST OR SINGLE ENTRY)
 start_date: 2023-09-12 # YYYY-MM-DD - (LIST OR SINGLE ENTRY)
 end_date: 2023-09-13 # YYYY-MM-DD - (LIST OR SINGLE ENTRY)
 days: # Array of day names - DEFAULTS TO `null`
-weekends: false # FALSE BY DEFAULT
+weekends: false # Only search for weekend bookings (Fri/Sat nights). FALSE BY DEFAULT
 nights: 1 # 1 BY DEFAULT
 continuous: true # DEFAULTS TO TRUE
 polling_interval: 5 # DEFAULTS TO 10 , CAN'T BE LESS THAN 5


### PR DESCRIPTION
# Description

Clarify comment for --weekends flag in example yaml config

The --weekends flag is intended to mean "weekends only" and will exclude weekdays from the search


[//]: # (Please include a summary of the changes and a link/description of the related issue.)
[//]: # (Please also include relevant motivation and context.)


# Has This Been Tested?

[//]: # (Please describe the tests that you ran to verify your changes. Provide instructions to reproduce.)
[//]: # (Please also list any relevant details for your test configuration)

No. But it's just a minor clarification to the documentation.

# Checklist:

- [x] I've read the [contributing guidelines](https://juftin.com/camply/contributing) of this project
- [ ] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation
