### PR TITLE
🐛 add accept-language header to goingtocamp requests

### DIFF
--- a/camply/providers/going_to_camp/going_to_camp_provider.py
+++ b/camply/providers/going_to_camp/going_to_camp_provider.py
@@ -335,8 +335,11 @@ class GoingToCamp(BaseProvider):
         url = None
         if endpoint:
             url = endpoint.format(hostname)
-        user_agent = {"User-Agent": UserAgent(browsers=["chrome"]).random}
-        response = requests.get(url=url, headers=user_agent, params=params, timeout=30)
+        headers = {
+            "User-Agent": UserAgent(browsers=["chrome"]).random,
+            "Accept-Language": "en-US,en;q=0.9",
+        }
+        response = requests.get(url=url, headers=headers, params=params, timeout=30)
         if response.ok is False:
             error_message = f"Receiving bad data from GoingToCamp API: status_code: {response.status_code}: {response.text}"
             logger.error(error_message)


### PR DESCRIPTION
# Description
This PR addresses the issue reported in #328, where API requests from camply to the GoingToCamp WA site were being blocked by DataDome, resulting in a 403 captcha error.

Upon examining the network requests on the GoingToCamp WA site, I observed that their API calls included a large set of HTTP headers, including those related to DataDome's bot protection. To isolate the essential headers required to prevent the API request from being rejected, I just copied the request and removed headers one by one. I identified that retaining only the `User-Agent` and `Accept-Language` headers circumvented the issue.

Further investigation into the [DataDome Request Validation API](https://docs.datadome.co/reference/validate-request) revealed that the Accept-Language header is among the top headers validated by DataDome. Including this header makes our API requests appear more legitimate (which it is), aligning closely with typical user requests, thus avoiding immediate rejection.

It's important to clarify that this modification does not represent a bypass of the captcha mechanism but rather an enhancement to the request headers to align with validation checks. This approach is currently effective, but it is susceptible to changes should GoingToCamp WA update their bot protection strategies.

I'm aware of your comment about captchas https://github.com/juftin/camply/issues/287#issuecomment-1673532963, so please close this if this is not something you're into. Not intending to break captcha with this, just replicating the network request on their website more accurately with a single header addition.

# Has This Been Tested?

### Before
![Screenshot 2024-04-26 at 2 13 24 PM](https://github.com/juftin/camply/assets/395354/85b41647-b334-418f-942c-77a8b168894c)

### After
![Screenshot 2024-04-26 at 2 13 48 PM](https://github.com/juftin/camply/assets/395354/ae3e3200-3f29-425a-8818-fe2fad306dc0)


# Checklist:

- [x] I've read the [contributing guidelines](https://juftin.com/camply/contributing) of this project
- [x] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation
