### PR TITLE
GoingToCamp: Fix session usage

### DIFF
--- a/camply/providers/going_to_camp/going_to_camp_provider.py
+++ b/camply/providers/going_to_camp/going_to_camp_provider.py
@@ -8,7 +8,6 @@ import sys
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import requests
 from fake_useragent import UserAgent
 from pydantic import ValidationError
 
@@ -339,7 +338,7 @@ class GoingToCamp(BaseProvider):
             "User-Agent": UserAgent(browsers=["chrome"]).random,
             "Accept-Language": "en-US,en;q=0.9",
         }
-        response = requests.get(url=url, headers=headers, params=params, timeout=30)
+        response = self.session.get(url=url, headers=headers, params=params, timeout=30)
         if response.ok is False:
             error_message = f"Receiving bad data from GoingToCamp API: status_code: {response.status_code}: {response.text}"
             logger.error(error_message)


### PR DESCRIPTION
# Description

The `GoingToCamp` provider doesn't reuse connections to the API because it doesn't use the requests session correctly:

```
[2024-04-28 19:08:44] DEBUG    Starting new HTTPS connection (1): reservation.pc.gc.ca:443                                                                                        
[2024-04-28 19:08:45] DEBUG    https://reservation.pc.gc.ca:443 "GET /api/resourceLocation HTTP/1.1" 200 None                                                                     
[2024-04-28 19:08:45] DEBUG    Starting new HTTPS connection (1): reservation.pc.gc.ca:443                                                                                        
[2024-04-28 19:08:45] DEBUG    https://reservation.pc.gc.ca:443 "GET /api/maps HTTP/1.1" 200 None  
```

# Has This Been Tested?

Yes, with this change:

```
[2024-04-28 19:09:35] DEBUG    Starting new HTTPS connection (1): reservation.pc.gc.ca:443                                                                                        
[2024-04-28 19:09:36] DEBUG    https://reservation.pc.gc.ca:443 "GET /api/resourceLocation HTTP/1.1" 200 285741                                                                   
[2024-04-28 19:09:36] DEBUG    https://reservation.pc.gc.ca:443 "GET /api/maps HTTP/1.1" 200 4196808    
```

# Checklist:

- [x] I've read the [contributing guidelines](https://juftin.com/camply/contributing) of this project
- [x] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation
