### PR TITLE
🐛 persistent error notifications

### DIFF
--- a/camply/config/notification_config.py
+++ b/camply/config/notification_config.py
@@ -21,7 +21,7 @@ class PushoverConfig:
     """
 
     PUSHOVER_API_ENDPOINT: str = "https://api.pushover.net/1/messages.json"
-    PUSHOVER_DEFAULT_API_TOKEN: bytes = b"YWpjN3M1a2hhYTRlOG1zYWhncnFnaHduZGdtbmI3"
+    PUSHOVER_DEFAULT_API_TOKEN: bytes = b"YXBqOWlzNjRrdm5zZWt3YmEyeDZxaDV0cWhxbXI5"
     API_HEADERS: dict = {"Content-Type": "application/json"}
 
     PUSH_TOKEN: str = getenv("PUSHOVER_PUSH_TOKEN", None)

--- a/camply/notifications/pushover.py
+++ b/camply/notifications/pushover.py
@@ -34,6 +34,11 @@ class PushoverNotifications(BaseNotifications, logging.StreamHandler):
             )
             logger.error(warning_message)
             raise EnvironmentError(warning_message)
+        self.pushover_token = PushoverConfig.PUSH_TOKEN
+        if self.pushover_token in [None, ""]:
+            self.pushover_token = base64.b64decode(
+                PushoverConfig.PUSHOVER_DEFAULT_API_TOKEN
+            ).decode("utf-8")
 
     def send_message(self, message: str, **kwargs) -> requests.Response:
         """
@@ -47,17 +52,13 @@ class PushoverNotifications(BaseNotifications, logging.StreamHandler):
         -------
         requests.Response
         """
-        token = (
-            PushoverConfig.PUSH_TOKEN
-            if PushoverConfig.PUSH_TOKEN not in [None, ""]
-            else base64.b64decode(PushoverConfig.PUSHOVER_DEFAULT_API_TOKEN).decode(
-                "utf-8"
-            )
-        )
         response = self.session.post(
             url=PushoverConfig.PUSHOVER_API_ENDPOINT,
             params=dict(
-                token=token, user=PushoverConfig.PUSH_USER, message=message, **kwargs
+                token=self.pushover_token,
+                user=PushoverConfig.PUSH_USER,
+                message=message,
+                **kwargs,
             ),
         )
         try:

--- a/camply/search/base_search.py
+++ b/camply/search/base_search.py
@@ -117,6 +117,7 @@ class BaseCampingSearch(ABC):
                 AvailableCampsite
             ] = self.load_campsites_from_file()
             self.loaded_campsites: Set[AvailableCampsite] = self.campsites_found.copy()
+        self.search_attempts: int = 0
 
     @property
     def search_days(self) -> List[datetime]:
@@ -274,6 +275,7 @@ class BaseCampingSearch(ABC):
             )
             logger.info(campsite_availability_message)
             raise CampsiteNotFoundError(campsite_availability_message)
+        self.search_attempts += 1
         return matching_campgrounds
 
     @classmethod
@@ -581,7 +583,8 @@ class BaseCampingSearch(ABC):
                     search_once=search_once,
                 )
             except Exception as e:
-                self.notifier.last_gasp(error=e)
+                if self.search_attempts >= 1:
+                    self.notifier.last_gasp(error=e)
                 raise e
         else:
             starting_count = len(self.campsites_found)


### PR DESCRIPTION
There is an issue where an improperly set up camply config in a constantly restarting docker container sends notifications all day. In the case of pushover, a process sent ~4,500 notifications today (and I believe they're error messages). This PR only emits the "last gasp" error notification if the search has run at least once. 

It also replaces the built-in Pushover token - which resolves an issue for the month of May where the token limit is reached.