### PR TITLE
🐛 yellowstone date filtering

### DIFF
--- a/camply/search/search_yellowstone.py
+++ b/camply/search/search_yellowstone.py
@@ -92,9 +92,11 @@ class SearchYellowstone(BaseCampingSearch):
         )
         campsite_df = self.campsites_to_df(campsites=matching_campsites)
         campsite_df_validated = self._filter_date_overlap(campsites=campsite_df)
+        time_window_start = min(self.search_days)
         time_window_end = max(self.search_days) + timedelta(days=1)
         compiled_campsite_df = campsite_df_validated[
-            campsite_df_validated.booking_end_date <= pd.Timestamp(time_window_end)
+            (campsite_df_validated.booking_date >= pd.Timestamp(time_window_start))
+            & (campsite_df_validated.booking_end_date <= pd.Timestamp(time_window_end))
         ]
         compiled_campsites = self.df_to_campsites(campsite_df=compiled_campsite_df)
         return compiled_campsites


### PR DESCRIPTION
## Summary
```shell
camply campsites --provider yellowstone --start-date 2025-07-04 --end-date 2025-07-08 --notifications silent --equipment RV 40 --campground YLYC:RV --nights 4
```

The issues I'm having is that even with the 4 consecutive nights flag, I'm getting dates for July 1 - 4, not 4 - 7. 