### PR TITLE
🐛 virginia state parks - tylerapp

### DIFF
--- a/camply/providers/usedirect/variations.py
+++ b/camply/providers/usedirect/variations.py
@@ -62,8 +62,8 @@ class VirginiaStateParks(UseDirectProvider):
     Virginia State Parks
     """
 
-    base_url = "https://virginiardr.usedirect.com"
-    campground_url = "https://VirginiaStateParks.com"
+    base_url = "https://prod-va-rdr.recreation-management.tylerapp.com"
+    campground_url = "https://reservevaparks.com"
     rdr_path = "virginiardr/"
     booking_path = "Web"
     state_code = "VA"

--- a/tests/cli/usedirect/cassettes/test_virginia_state_parks_campgrounds.yaml
+++ b/tests/cli/usedirect/cassettes/test_virginia_state_parks_campgrounds.yaml
@@ -6,7 +6,7 @@ interactions:
                   - Mozilla/5.0 (X11; CrOS i686 12.433.109) AppleWebKit/534.30 (KHTML, like Gecko)
                     Chrome/12.0.742.93 Safari/534.30
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/search/filters
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/search/filters
       response:
           body:
               string:
@@ -289,7 +289,7 @@ interactions:
                   - Mozilla/5.0 (X11; CrOS i686 12.433.109) AppleWebKit/534.30 (KHTML, like Gecko)
                     Chrome/12.0.742.93 Safari/534.30
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/fd/citypark
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/fd/citypark
       response:
           body:
               string:
@@ -538,7 +538,7 @@ interactions:
                   - Mozilla/5.0 (X11; CrOS i686 12.433.109) AppleWebKit/534.30 (KHTML, like Gecko)
                     Chrome/12.0.742.93 Safari/534.30
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/fd/places
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/fd/places
       response:
           body:
               string:
@@ -693,7 +693,7 @@ interactions:
                   - Mozilla/5.0 (X11; CrOS i686 12.433.109) AppleWebKit/534.30 (KHTML, like Gecko)
                     Chrome/12.0.742.93 Safari/534.30
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/fd/facilities
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/fd/facilities
       response:
           body:
               string:

--- a/tests/cli/usedirect/cassettes/test_virginia_state_parks_campsites.yaml
+++ b/tests/cli/usedirect/cassettes/test_virginia_state_parks_campsites.yaml
@@ -6,7 +6,7 @@ interactions:
                   - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML,
                     like Gecko) Chrome/52.0.2762.73 Safari/537.36
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/search/filters
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/search/filters
       response:
           body:
               string:
@@ -289,7 +289,7 @@ interactions:
                   - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML,
                     like Gecko) Chrome/52.0.2762.73 Safari/537.36
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/fd/citypark
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/fd/citypark
       response:
           body:
               string:
@@ -538,7 +538,7 @@ interactions:
                   - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML,
                     like Gecko) Chrome/52.0.2762.73 Safari/537.36
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/fd/places
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/fd/places
       response:
           body:
               string:
@@ -693,7 +693,7 @@ interactions:
                   - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML,
                     like Gecko) Chrome/52.0.2762.73 Safari/537.36
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/fd/facilities
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/fd/facilities
       response:
           body:
               string:
@@ -939,7 +939,7 @@ interactions:
                   - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML,
                     like Gecko) Chrome/52.0.2762.73 Safari/537.36
           method: POST
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/search/grid
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/search/grid
       response:
           body:
               string:

--- a/tests/cli/usedirect/cassettes/test_virginia_state_parks_recreation_areas.yaml
+++ b/tests/cli/usedirect/cassettes/test_virginia_state_parks_recreation_areas.yaml
@@ -7,7 +7,7 @@ interactions:
                     Safari/537.36 Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10
                     (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/search/filters
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/search/filters
       response:
           body:
               string:
@@ -291,7 +291,7 @@ interactions:
                     Safari/537.36 Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10
                     (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/fd/citypark
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/fd/citypark
       response:
           body:
               string:
@@ -541,7 +541,7 @@ interactions:
                     Safari/537.36 Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10
                     (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/fd/places
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/fd/places
       response:
           body:
               string:
@@ -697,7 +697,7 @@ interactions:
                     Safari/537.36 Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10
                     (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10
           method: GET
-          uri: https://virginiardr.usedirect.com/virginiardr/rdr/fd/facilities
+          uri: https://prod-va-rdr.recreation-management.tylerapp.com/virginiardr/rdr/fd/facilities
       response:
           body:
               string:


### PR DESCRIPTION
## Summary

Virginia State Parks moved to https://reservevaparks.com and now uses https://prod-va-rdr.recreation-management.tylerapp.com

Closes #386 