### PR TITLE
🐛 fix ReserveCalifornia booking URLs to use new path format

### DIFF
--- a/camply/providers/usedirect/usedirect.py
+++ b/camply/providers/usedirect/usedirect.py
@@ -66,6 +66,7 @@ class UseDirectProvider(BaseProvider, ABC):
 
     booking_path_params: bool = True
     booking_path: str = "Web/Default.aspx"
+    booking_path_hash: bool = True
 
     @property
     @abstractmethod
@@ -449,7 +450,10 @@ class UseDirectProvider(BaseProvider, ABC):
         recreation_area = self.usedirect_rec_areas[facility.recreation_area_id]
         booking_url = f"{self.campground_url}/{self.booking_path}"
         if self.booking_path_params is True:
-            booking_url = f"{booking_url}#!park/{recreation_area.recreation_area_id}/{facility_id}"
+            if self.booking_path_hash:
+                booking_url = f"{booking_url}#!park/{recreation_area.recreation_area_id}/{facility_id}"
+            else:
+                booking_url = f"{booking_url}/{recreation_area.recreation_area_id}/{facility_id}"
         if unit.UnitCategoryId is None:
             unit.UnitCategoryId = -1
         if unit.UnitTypeGroupId is None:

--- a/camply/providers/usedirect/variations.py
+++ b/camply/providers/usedirect/variations.py
@@ -31,6 +31,8 @@ class ReserveCalifornia(UseDirectProvider):
     campground_url = "https://www.reservecalifornia.com"
     state_code = "CA"
     rdr_path = ""
+    booking_path = "park"
+    booking_path_hash = False
 
 
 class FloridaStateParks(UseDirectProvider):


### PR DESCRIPTION
## Summary

- ReserveCalifornia's new site uses `/park/{rec_area_id}/{facility_id}` instead of the old `/Web/Default.aspx#!park/{rec_area_id}/{facility_id}` hash-fragment format
- Added `booking_path_hash` class attribute to `UseDirectProvider` to support both URL styles, defaulting to `True` (existing behavior) for backward compatibility
- Set `booking_path = "park"` and `booking_path_hash = False` on `ReserveCalifornia` to generate correct URLs

**Before:** `https://www.reservecalifornia.com/Web/Default.aspx#!park/695/628`
**After:** `https://www.reservecalifornia.com/park/695/628`

Closes #392

## Test plan

- [ ] Verify ReserveCalifornia campsite search produces correct booking URLs
- [ ] Verify other UseDirect providers (e.g. OhioStateParks, FloridaStateParks) still produce correct hash-fragment URLs
- [ ] Run existing test suite to confirm no regressions

Made with [Cursor](https://cursor.com)