### PR TITLE
build: multi-architecture docker builds (amd64, arm64)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,6 +12,8 @@ jobs:
     docker:
         runs-on: ubuntu-latest
         steps:
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
             - name: docker
               uses: juftin/actions/taskfile@v1
               with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,6 +42,8 @@ jobs:
                   RELEASE_VERSION="${TAG_NAME#v}"
                   echo "RELEASE_VERSION=${RELEASE_VERSION}"
                   echo "RELEASE_VERSION=${RELEASE_VERSION}" >> ${GITHUB_ENV}
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
             - name: docker
               uses: juftin/actions/taskfile@v1
               with:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -95,7 +95,7 @@ tasks:
               --tag {{.DOCKER_REPO}}:{{.RELEASE_VERSION}} \
               --tag {{.DOCKER_REPO}}:latest \
               --file {{.ROOT_DIR}}/Dockerfile \
-              {{.CLI_ARGS | default ""}} \
+              --platform linux/amd64,linux/arm64 {{.CLI_ARGS | default ""}} \
               {{.ROOT_DIR}}
         vars:
             RELEASE_VERSION:


### PR DESCRIPTION
This PR adds support for building the Camply Docker image for both `linux/amd64` and `linux/arm64` architectures.

### Changes
- Injected `docker/setup-qemu-action@v3` into the GitHub Actions workflows (`docker.yaml` and `publish.yaml`) to emulate ARM environments on the standard Ubuntu runners.
- Updated `Taskfile.yaml` to pass the `--platform linux/amd64,linux/arm64` flag to the `docker buildx build` command.

### Testing
- Successfully tested the multi-arch build process on a fork by temporarily pushing to GHCR. Both `amd64` and `arm64` architectures were successfully compiled and pushed via the manifest list.

This allows the Camply Docker image to natively support Raspberry Pi and other ARM64 devices without emulation overhead.