### PR TITLE
ci(test): skip coverage comment on fork PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,6 @@ jobs:
                   install: true
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   annotations-pytest: ${{ matrix.python == '3.12' && true || false }}
-                  pytest-coverage: ${{ matrix.python == '3.12' && github.event_name == 'pull_request' && true || false }}
+                  pytest-coverage: ${{ matrix.python == '3.12' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'juftin/camply' && true || false }}
               env:
                   UV_PYTHON: ${{ matrix.python }}


### PR DESCRIPTION
## Problem

When external contributors submit PRs from forks, the `pytest-coverage-comment` action fails with `HttpError: Resource not accessible by integration`.

This is because GitHub overrides GITHUB_TOKEN permissions for first-time contributor fork PRs, preventing the action from posting PR comments — even though the workflow declares `pull-requests: write`.

The result is a false CI failure unrelated to the submitted code.

## Fix

Only run the coverage comment step on PRs from the main repo (`juftin/camply`), skipping external forks entirely. Coverage still generates locally — it just won't attempt post a PR comment on fork PRs.

## Testing

Driven by [PR #407](https://github.com/juftin/camply/pull/407) — a legitimate fork PR blocked by this despite all 108 tests passing.