### PR TITLE
🐛 Prevent sending empty notifications to webhook

### DIFF
--- a/camply/notifications/webhook.py
+++ b/camply/notifications/webhook.py
@@ -53,6 +53,9 @@ class WebhookNotifications(BaseNotifications):
         ----------
         campsites: List[AvailableCampsite]
         """
+        if not campsites:
+            logger.debug("No campsites to send to webhook.")
+            return
         webhook_body = WebhookBody(campsites=campsites).json().encode("utf-8")
         response = self.session.post(url=self.webhook_url, data=webhook_body)
         try:

--- a/camply/search/base_search.py
+++ b/camply/search/base_search.py
@@ -366,14 +366,14 @@ class BaseCampingSearch(ABC):
         )
         logger.info(f"{len(new_campsites)} New Campsites Found.")
         self.campsites_found.update(new_campsites)
-        logged_campsites = list(new_campsites)
-        self._handle_notifications(
-            retryer=retryer,
-            notifier=self.notifier,
-            logged_campsites=logged_campsites,
-            continuous_search_attempts=continuous_search_attempts,
-            notify_first_try=notify_first_try,
-        )
+        if new_campsites:
+            self._handle_notifications(
+                retryer=retryer,
+                notifier=self.notifier,
+                logged_campsites=list(new_campsites),
+                continuous_search_attempts=continuous_search_attempts,
+                notify_first_try=notify_first_try,
+            )
         return list(self.campsites_found)
 
     @classmethod

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -2,8 +2,15 @@
 Notification Testing
 """
 
+from unittest.mock import MagicMock
+
+from pytest import MonkeyPatch
+
 from camply import AvailableCampsite
+from camply.config.notification_config import WebhookConfig
 from camply.notifications import PushoverNotifications
+from camply.notifications.webhook import WebhookNotifications
+from camply.search.base_search import BaseCampingSearch
 from tests.conftest import vcr_cassette
 
 
@@ -23,3 +30,45 @@ def test_pushover_campsite(available_campsite: AvailableCampsite):
     """
     pusher = PushoverNotifications()
     pusher.send_campsites(campsites=[available_campsite])
+
+
+def test_no_notifications_when_no_new_campsites():
+    """
+    Verify that notifications are not sent when no new campsites are found
+    """
+    self_mock = MagicMock(spec=BaseCampingSearch)
+    self_mock._get_polling_minutes.return_value = 10
+    self_mock._search_matching_campsites_available.return_value = ["campsite1"]
+    self_mock.campsites_found = {"campsite1"}
+
+    BaseCampingSearch._continuous_search_retry(
+        self=self_mock,
+        log=False,
+        verbose=False,
+        polling_interval=10,
+        continuous_search_attempts=1,
+        notification_provider="silent",
+        notify_first_try=False,
+        search_once=True,
+    )
+
+    self_mock.assemble_availabilities.assert_called_once_with(
+        matching_data=[], log=False, verbose=False
+    )
+    self_mock._handle_notifications.assert_not_called()
+
+
+def test_webhook_notifier_empty_campsites(monkeypatch: MonkeyPatch):
+    """
+    Verify WebhookNotifications does not send empty campsite lists
+    """
+    monkeypatch.setattr(WebhookConfig, "WEBHOOK_URL", "http://example.com/webhook")
+
+    mock_session = MagicMock()
+
+    notifier = WebhookNotifications()
+    notifier.session = mock_session
+
+    notifier.send_campsites([])
+
+    mock_session.post.assert_not_called()


### PR DESCRIPTION
# Description

This PR fixes an issue where empty notifications were still being sent to the webhook listener when no new campsites were found during a search.
    
### Motivation and Context
When running `camply` in continuous search mode, it periodically checks for campsite availability. If a search completes and finds 0 *new* campsites (either because nothing was found, or all found sites were already logged), the notification pipeline  was still being triggered. 
    
For the webhook provider, this resulted in an empty POST request (containing `{"campsites": []}`) being sent to the configured `WEBHOOK_URL` on every single polling interval. This caused unnecessary network traffic and noise for webhook  listeners.
    
### Changes
*   **`camply/search/base_search.py`**: Added a check (`if new_campsites:`) to only call `_handle_notifications` when new  campsites are actually discovered.
*   **`camply/notifications/webhook.py`**: Added a guard clause in `send_campsites` to return early if the `campsites` list  is empty, preventing empty POST requests.
    
    
# Has This Been Tested?
    
I have added unit tests in `tests/test_notifications.py` to verify these changes:
*   `test_no_notifications_when_no_new_campsites`: Verifies that `MultiNotifierProvider.send_campsites` is not called when `_continuous_search_retry` finds no new campsites.
*   `test_webhook_notifier_empty_campsites`: Verifies that `WebhookNotifications` does not make a POST request when  `send_campsites` is called with an empty list.
    
    ### Test Configuration
    *   **OS:** Linux
    *   **Python Version:** 3.13.12
    *   **Pytest Version:** 9.1.1
    *   **Command run:** `PUSHOVER_PUSH_USER=dummy PUSHOVER_PUSH_TOKEN=dummy pytest -o addopts="" -W ignore
  tests/test_notifications.py`
    
    
    # Checklist:
    
    - [x] I've read the contributing guidelines of this project
    - [ ] I've added a `BUMP_MAJOR`, `BUMP_MINOR`, or `BUMP_PATCH` label to this PR to increment the version
    - [x] I've installed and used `.pre_commit` on all my code
    - [x] I have documented my code, particularly in hard-to-understand areas
    - [x] I have made any necessary corresponding changes to the documentation