### PR TITLE
docs: add CampSage (hosted web front-end) to a Related Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ Head over to the [camply documentation](https://juftin.com/camply/) to see what 
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
+## Related Projects
+
+- [**CampSage**](https://campsage.app) — a hosted, no-install web front-end that surfaces
+  camply-powered campsite availability and last-minute cancellations on a live map, with free
+  email alerts when a sold-out spot opens up.
+
 ## Contributing
 
 Camply doesn't support your favorite campsite booking provider yet? Consider


### PR DESCRIPTION
Hi 👋 — thanks for camply, it's great.

I built a hosted, no-install web front-end on top of it — [**CampSage**](https://campsage.app) — that surfaces camply-powered availability and last-minute cancellations on a live map with free email alerts when a sold-out spot opens up.

This small PR adds a **Related Projects** section linking it, in case it's handy for folks who want a web UI without running camply locally. Completely understand if you'd rather keep the README lean — happy to tweak the wording or close it. Thanks either way! 🙏